### PR TITLE
docs: document session database

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Bookmarks
 - On first load, any existing `localStorage` bookmarks are migrated to IndexedDB.
 - The Timeline toolbar has a toggle to show only bookmarked items and a count of current bookmarks. Clearing bookmarks removes them from both stores.
 
+Session Database
+----------------
+
+- `src/utils/session-db.ts` wraps IndexedDB to cache session data and file hashes.
+- Stores:
+  - `sessions`: full session payloads keyed by `id` with metadata, events, and timestamps.
+  - `fileHashes`: hash of each file path to avoid recomputing diffs.
+- Sessions opened in the viewer are persisted with `saveSession(id, meta, events)` and can be restored later via `loadSession(id)` or enumerated with `listSessions()`. Use `deleteSession(id)` to remove one.
+
+See [docs/session-db.md](docs/session-db.md) for a schema overview and CRUD examples.
+
 Export (JSON / Markdown / HTML)
 -------------------------------
 

--- a/docs/session-db.md
+++ b/docs/session-db.md
@@ -1,0 +1,50 @@
+# Session DB
+
+`src/utils/session-db.ts` provides a thin wrapper around IndexedDB for caching session content and file hashes.
+
+## Stores
+
+### sessions
+
+```ts
+interface SessionRecord {
+  id: string
+  meta?: SessionMetaParsed
+  events: ResponseItemParsed[]
+  createdAt: number
+  updatedAt: number
+}
+```
+
+### fileHashes
+
+```ts
+interface FileHashRecord {
+  path: string
+  hash: string
+  updatedAt: number
+}
+```
+
+## CRUD snippets
+
+```ts
+import {
+  saveSession,
+  loadSession,
+  listSessions,
+  deleteSession,
+  putHash,
+  getHash
+} from '../src/utils/session-db'
+
+await saveSession(id, meta, events)        // create/update
+const session = await loadSession(id)      // read
+const all = await listSessions()           // list
+await deleteSession(id)                    // delete
+
+await putHash(path, hash)                  // create/update hash
+const hashRec = await getHash(path)        // read hash
+```
+
+


### PR DESCRIPTION
## Summary
- explain the session database utility in README
- add `docs/session-db.md` describing IndexedDB stores and CRUD examples

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0710486788328a9892962a72cb501