### PR TITLE
feat: add custom element shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ node_modules/
 # tasks/
 
 
-dist/
+dist/*
+!dist/element.js
+!dist/element.d.ts
 scripts/
 error-logs/
 .cursor/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ A lightweight UI to inspect Codex CLI session logs. Includes:
 - Export to JSON/Markdown
 - Bookmarks with IndexedDB persistence (and migration from localStorage)
 
+Web Component
+--------------
+
+This project exposes a minimal `<codex-session-viewer>` custom element. It self-registers when `dist/element.js` is loaded and the class is also available for direct import.
+
+```html
+<script type="module" src="/dist/element.js"></script>
+<codex-session-viewer></codex-session-viewer>
+```
+
+```ts
+import 'codex-session-viewer/element.js'
+```
+
 Getting Started
 ---------------
 

--- a/dist/element.d.ts
+++ b/dist/element.d.ts
@@ -1,14 +1,14 @@
 export declare class CodexSessionViewer extends HTMLElement {
-  private _session;
-  static get observedAttributes(): string[];
-  get src(): string | null;
-  set src(value: string | null);
-  get theme(): string | null;
-  set theme(value: string | null);
-  get session(): unknown;
-  set session(value: unknown);
-  connectedCallback(): void;
-  load(fileOrUrl: File | string): Promise<void>;
-  export(options?: unknown): Promise<void>;
+    private _session;
+    static get observedAttributes(): string[];
+    get src(): string | null;
+    set src(value: string | null);
+    get theme(): string | null;
+    set theme(value: string | null);
+    get session(): unknown;
+    set session(value: unknown);
+    connectedCallback(): void;
+    load(_fileOrUrl: File | string): Promise<void>;
+    export(_options?: unknown): Promise<void>;
 }
 export default CodexSessionViewer;

--- a/dist/element.d.ts
+++ b/dist/element.d.ts
@@ -1,0 +1,14 @@
+export declare class CodexSessionViewer extends HTMLElement {
+  private _session;
+  static get observedAttributes(): string[];
+  get src(): string | null;
+  set src(value: string | null);
+  get theme(): string | null;
+  set theme(value: string | null);
+  get session(): unknown;
+  set session(value: unknown);
+  connectedCallback(): void;
+  load(fileOrUrl: File | string): Promise<void>;
+  export(options?: unknown): Promise<void>;
+}
+export default CodexSessionViewer;

--- a/dist/element.js
+++ b/dist/element.js
@@ -1,0 +1,54 @@
+export class CodexSessionViewer extends HTMLElement {
+  constructor() {
+    super();
+    this._session = null;
+  }
+  static get observedAttributes() {
+    return ['src', 'theme'];
+  }
+  get src() {
+    return this.getAttribute('src');
+  }
+  set src(value) {
+    if (value === null) {
+      this.removeAttribute('src');
+    } else {
+      this.setAttribute('src', value);
+    }
+  }
+  get theme() {
+    return this.getAttribute('theme');
+  }
+  set theme(value) {
+    if (value === null) {
+      this.removeAttribute('theme');
+    } else {
+      this.setAttribute('theme', value);
+    }
+  }
+  get session() {
+    return this._session;
+  }
+  set session(value) {
+    this._session = value;
+  }
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const shadow = this.attachShadow({ mode: 'open' });
+      const container = document.createElement('div');
+      container.textContent = 'codex-session-viewer';
+      shadow.appendChild(container);
+    }
+  }
+  async load(_fileOrUrl) {
+    this.dispatchEvent(new CustomEvent('session-load'));
+  }
+  async export(_options) {
+    this.dispatchEvent(new CustomEvent('export-start'));
+    this.dispatchEvent(new CustomEvent('export-done'));
+  }
+}
+if (!customElements.get('codex-session-viewer')) {
+  customElements.define('codex-session-viewer', CodexSessionViewer);
+}
+export default CodexSessionViewer;

--- a/dist/element.js
+++ b/dist/element.js
@@ -1,54 +1,56 @@
 export class CodexSessionViewer extends HTMLElement {
-  constructor() {
-    super();
-    this._session = null;
-  }
-  static get observedAttributes() {
-    return ['src', 'theme'];
-  }
-  get src() {
-    return this.getAttribute('src');
-  }
-  set src(value) {
-    if (value === null) {
-      this.removeAttribute('src');
-    } else {
-      this.setAttribute('src', value);
+    constructor() {
+        super(...arguments);
+        this._session = null;
     }
-  }
-  get theme() {
-    return this.getAttribute('theme');
-  }
-  set theme(value) {
-    if (value === null) {
-      this.removeAttribute('theme');
-    } else {
-      this.setAttribute('theme', value);
+    static get observedAttributes() {
+        return ['src', 'theme'];
     }
-  }
-  get session() {
-    return this._session;
-  }
-  set session(value) {
-    this._session = value;
-  }
-  connectedCallback() {
-    if (!this.shadowRoot) {
-      const shadow = this.attachShadow({ mode: 'open' });
-      const container = document.createElement('div');
-      container.textContent = 'codex-session-viewer';
-      shadow.appendChild(container);
+    get src() {
+        return this.getAttribute('src');
     }
-  }
-  async load(_fileOrUrl) {
-    this.dispatchEvent(new CustomEvent('session-load'));
-  }
-  async export(_options) {
-    this.dispatchEvent(new CustomEvent('export-start'));
-    this.dispatchEvent(new CustomEvent('export-done'));
-  }
+    set src(value) {
+        if (value === null) {
+            this.removeAttribute('src');
+        }
+        else {
+            this.setAttribute('src', value);
+        }
+    }
+    get theme() {
+        return this.getAttribute('theme');
+    }
+    set theme(value) {
+        if (value === null) {
+            this.removeAttribute('theme');
+        }
+        else {
+            this.setAttribute('theme', value);
+        }
+    }
+    get session() {
+        return this._session;
+    }
+    set session(value) {
+        this._session = value;
+    }
+    connectedCallback() {
+        if (!this.shadowRoot) {
+            const shadow = this.attachShadow({ mode: 'open' });
+            const container = document.createElement('div');
+            container.textContent = 'codex-session-viewer';
+            shadow.appendChild(container);
+        }
+    }
+    async load(_fileOrUrl) {
+        this.dispatchEvent(new CustomEvent('session-load'));
+    }
+    async export(_options) {
+        this.dispatchEvent(new CustomEvent('export-start'));
+        this.dispatchEvent(new CustomEvent('export-done'));
+    }
 }
 if (!customElements.get('codex-session-viewer')) {
-  customElements.define('codex-session-viewer', CodexSessionViewer);
+    customElements.define('codex-session-viewer', CodexSessionViewer);
 }
 export default CodexSessionViewer;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    "./element.js": "./dist/element.js"
+  },
+  "types": "dist/element.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/element.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && tsc -p tsconfig.element.json",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,0 +1,63 @@
+export class CodexSessionViewer extends HTMLElement {
+  private _session: unknown = null;
+
+  static get observedAttributes() {
+    return ['src', 'theme'];
+  }
+
+  get src(): string | null {
+    return this.getAttribute('src');
+  }
+
+  set src(value: string | null) {
+    if (value === null) {
+      this.removeAttribute('src');
+    } else {
+      this.setAttribute('src', value);
+    }
+  }
+
+  get theme(): string | null {
+    return this.getAttribute('theme');
+  }
+
+  set theme(value: string | null) {
+    if (value === null) {
+      this.removeAttribute('theme');
+    } else {
+      this.setAttribute('theme', value);
+    }
+  }
+
+  get session(): unknown {
+    return this._session;
+  }
+
+  set session(value: unknown) {
+    this._session = value;
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const shadow = this.attachShadow({ mode: 'open' });
+      const container = document.createElement('div');
+      container.textContent = 'codex-session-viewer';
+      shadow.appendChild(container);
+    }
+  }
+
+  async load(_fileOrUrl: File | string) {
+    this.dispatchEvent(new CustomEvent('session-load'));
+  }
+
+  async export(_options?: unknown) {
+    this.dispatchEvent(new CustomEvent('export-start'));
+    this.dispatchEvent(new CustomEvent('export-done'));
+  }
+}
+
+if (!customElements.get('codex-session-viewer')) {
+  customElements.define('codex-session-viewer', CodexSessionViewer);
+}
+
+export default CodexSessionViewer;

--- a/tsconfig.element.json
+++ b/tsconfig.element.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "target": "ES2017",
+    "lib": ["ES2017", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/element.ts"]
+}


### PR DESCRIPTION
## Summary
- add minimal `<codex-session-viewer>` custom element that self-registers
- expose ESM entry and types for the element
- document component usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c07b0c7b4c8328ba60f3241cbcdb34