### PR TITLE
feat: parse hyphenated timestamp strings with time

### DIFF
--- a/src/utils/timestamp.test.ts
+++ b/src/utils/timestamp.test.ts
@@ -12,6 +12,11 @@ describe('parseTimestampFromPath', () => {
     expect(ts).toBe(Date.UTC(2024, 5, 10))
   })
 
+  it('parses yyyy-mm-ddThh-mm-ss', () => {
+    const ts = parseTimestampFromPath('logs/2024-06-10T12-30-00.txt')
+    expect(ts).toBe(Date.UTC(2024, 5, 10, 12, 30, 0))
+  })
+
   it('parses epoch seconds', () => {
     const ts = parseTimestampFromPath('foo/1718025600.json')
     expect(ts).toBe(1718025600 * 1000)

--- a/src/utils/timestamp.ts
+++ b/src/utils/timestamp.ts
@@ -1,4 +1,27 @@
 export function parseTimestampFromPath(p: string): number | null {
+  const m2 = p.match(/(20\d{2})[-_]?(\d{2})[-_]?(\d{2})T(\d{2})[-_]?(\d{2})[-_]?(\d{2})/)
+  if (m2) {
+    const y = Number(m2[1])
+    const mo = Number(m2[2])
+    const d = Number(m2[3])
+    const h = Number(m2[4])
+    const mi = Number(m2[5])
+    const s = Number(m2[6])
+    if (
+      mo >= 1 &&
+      mo <= 12 &&
+      d >= 1 &&
+      d <= 31 &&
+      h >= 0 &&
+      h <= 23 &&
+      mi >= 0 &&
+      mi <= 59 &&
+      s >= 0 &&
+      s <= 59
+    ) {
+      return Date.UTC(y, mo - 1, d, h, mi, s)
+    }
+  }
   const m1 = p.match(/(20\d{2})[-_]?(\d{2})[-_]?(\d{2})/)
   if (m1) {
     const y = Number(m1[1])


### PR DESCRIPTION
## Summary
- support parsing timestamps in `YYYY-MM-DDThh-mm-ss` format
- add unit test for parsing date-time strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c077b1ed6c83289e8419ec4d4924cc