### PR TITLE
docs: document timestamp parser utility

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -9,7 +9,7 @@ Scope options
 
 Default fields (CSV)
 - index (absolute index in input stream)
-- at (timestamp if present)
+- at (timestamp if present, derived with `parseTimestampFromPath` when exported from paths)
 - type (Message | Reasoning | FileChange | FunctionCall | LocalShellCall | WebSearchCall | CustomToolCall | Other)
 - role (Message only)
 - model (Message only)

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -2,12 +2,12 @@
 
 The All Sessions list supports two sort orders:
 
-- Newest (default): attempts to parse a timestamp from path (YYYY-MM-DD / YYYYMMDD / epoch). Falls back to name.
+- Newest (default): uses `parseTimestampFromPath` to extract a timestamp from the path (YYYY-MM-DD / YYYYMMDD / epoch). Falls back to name when none is found.
 - Name: ascending path name (A → Z).
 
 Implementation details
-- A `sortKey` is computed in `useAutoDiscovery()` and exposed on each asset.
-- The UI also includes a local parser for robustness.
+- A `sortKey` is computed in `useAutoDiscovery()` using `parseTimestampFromPath` from `src/utils/timestamp.ts` and exposed on each asset.
+- `SessionsList` also calls this utility locally for robustness.
 
 Limitations
 - If no timestamp can be parsed, items may group under the fallback.


### PR DESCRIPTION
## Summary
- describe `parseTimestampFromPath` in sorting docs and how SessionsList uses it
- mention `parseTimestampFromPath` in export spec for deriving timestamps from paths

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c077b37f808328a9616c86b46961bf