### PR TITLE
Optimize file hashing with cached metadata

### DIFF
--- a/docs/session-db.md
+++ b/docs/session-db.md
@@ -17,11 +17,12 @@ interface SessionRecord {
 ```
 
 ### fileHashes
-
+Stores file hashes along with an optional modification timestamp to avoid re-hashing unchanged files.
 ```ts
 interface FileHashRecord {
   path: string
   hash: string
+  mtime?: number
   updatedAt: number
 }
 ```
@@ -43,7 +44,7 @@ const session = await loadSession(id)      // read
 const all = await listSessions()           // list
 await deleteSession(id)                    // delete
 
-await putHash(path, hash)                  // create/update hash
+await putHash(path, hash, mtime)           // create/update hash with modification time
 const hashRec = await getHash(path)        // read hash
 ```
 

--- a/src/utils/session-db.ts
+++ b/src/utils/session-db.ts
@@ -16,6 +16,7 @@ export interface FileHashRecord {
   path: string
   hash: string
   updatedAt: number
+  mtime?: number
 }
 
 interface SessionDBSchema extends DBSchema {
@@ -76,9 +77,9 @@ export async function deleteSession(id: string) {
   await db.delete('sessions', id)
 }
 
-export async function putHash(path: string, hash: string) {
+export async function putHash(path: string, hash: string, mtime?: number) {
   const db = await getDB()
-  const rec: FileHashRecord = { path, hash, updatedAt: Date.now() }
+  const rec: FileHashRecord = { path, hash, mtime, updatedAt: Date.now() }
   await db.put('fileHashes', rec)
 }
 

--- a/src/workers/fs-scanner.ts
+++ b/src/workers/fs-scanner.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { putHash } from '../utils/session-db'
+import { getHash, putHash } from '../utils/session-db'
 
 async function hashFile(file: File): Promise<string> {
   const buf = await file.arrayBuffer()
@@ -11,9 +11,13 @@ async function scanDir(dir: FileSystemDirectoryHandle, prefix = ''): Promise<voi
   for await (const [name, handle] of (dir as any).entries()) {
     const path = prefix ? `${prefix}/${name}` : name
     if (handle.kind === 'file') {
+      const existing = await getHash(path)
       const file = await handle.getFile()
+      const mtime = file.lastModified
+      if (existing?.mtime === mtime) continue
       const hash = await hashFile(file)
-      await putHash(path, hash)
+      if (existing?.hash === hash) continue
+      await putHash(path, hash, mtime)
     } else if (handle.kind === 'directory') {
       await scanDir(handle, path)
     }


### PR DESCRIPTION
## Summary
- Cache modification time alongside file hashes in session DB
- Skip hashing files when mtime matches cached record
- Avoid rewriting identical hashes in fs scanner

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c077b77dd8832881521c7969bebd75