### PR TITLE
feat: add progress and abort hooks to fs scanner worker

### DIFF
--- a/src/workers/fs-scanner.ts
+++ b/src/workers/fs-scanner.ts
@@ -7,23 +7,33 @@ async function hashFile(file: File): Promise<string> {
   return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('')
 }
 
+let aborted = false
+
 async function scanDir(dir: FileSystemDirectoryHandle, prefix = ''): Promise<void> {
   for await (const [name, handle] of (dir as any).entries()) {
+    if (aborted) return
     const path = prefix ? `${prefix}/${name}` : name
     if (handle.kind === 'file') {
       const file = await handle.getFile()
       const hash = await hashFile(file)
       await putHash(path, hash)
+      ;(self as any).postMessage({ type: 'progress', path })
     } else if (handle.kind === 'directory') {
       await scanDir(handle, path)
     }
   }
 }
 
-self.onmessage = async (e: MessageEvent<FileSystemDirectoryHandle[]>) => {
-  const roots = e.data
+self.onmessage = async (e: MessageEvent<any>) => {
+  const msg = e.data
+  if (msg === 'abort' || msg?.type === 'abort') {
+    aborted = true
+    return
+  }
+  const roots: FileSystemDirectoryHandle[] = msg.roots ?? msg
   for (const dir of roots) {
+    if (aborted) break
     await scanDir(dir)
   }
-  ;(self as any).postMessage('done')
+  ;(self as any).postMessage(aborted ? 'aborted' : 'done')
 }


### PR DESCRIPTION
## Summary
- expose abort and progress hooks when starting filesystem scan
- send incremental progress updates from fs-scanner worker and handle abort messages

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c077b82dc883289ffa6e8940a472e2