### PR TITLE
docs: document file system scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Notes
 - The file tree ignores leading `./` and `/` and normalizes Windows paths.
 - Auto‑discovered project files: at build time we enumerate common source locations (e.g. `src/**`, `scripts/**`, `public/**`, plus a few root files). This augments the file tree even if your session has few or no `FileChange` events.
 - Auto‑detected sessions: during dev/build, files under `/.codex/sessions/**/*.{jsonl,ndjson,json}` (and `/sessions`, `/artifacts/sessions`) are discovered and listed. This only works for files that live inside the Vite project root; the app does not scan your filesystem at runtime.
+- For details on the indexing worker and the hashes it stores in IndexedDB, see [docs/fs-scanner.md](docs/fs-scanner.md).
  - If you have many sessions, use “View all (N)” for a searchable list; chips only show the first 12 for quick access.
 - URL hash preserves the “bookmarks only” toggle (`b=1`) and selected file (`f=path`).
 - URL hash also preserves optional filters when set: type (`t=<TypeFilter>`), role (`r=user|assistant|system`).

--- a/docs/fs-scanner.md
+++ b/docs/fs-scanner.md
@@ -1,0 +1,14 @@
+# File System Scanner
+
+The viewer runs a background worker that indexes local files to speed up diffing and session discovery.
+
+## Indexed Roots
+
+- **Current working directory** – the origin's root directory provided by the File System Access API.
+- **`.codex/sessions`** – if present, this folder is scanned to list session logs.
+
+Each file found under these roots is read and hashed with SHA-256. The resulting `{ path, hash }` pairs are stored in IndexedDB via the `fileHashes` store in `src/utils/session-db.ts`.
+
+## Privacy Notes
+
+The hashes never leave your browser, but they persist in IndexedDB. Because file paths and content digests are retained, they may reveal information about your project. Clear site data if you don't want this information stored locally.


### PR DESCRIPTION
## Summary
- describe how the file system scanner indexes the current working directory and `.codex/sessions`
- note hashes stored in IndexedDB and possible privacy implications
- link scanner documentation from the README

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c077b9e8008328a559655e1d47ebc8