### PR TITLE
feat: add theme system with picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "monaco-editor": "^0.49.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import useAutoDiscovery from './hooks/useAutoDiscovery'
 import SessionsList from './components/SessionsList'
 import { matchesEvent } from './utils/search'
 import ExportModal from './components/ExportModal'
+import ThemePicker from './components/ThemePicker'
 
 function DevButtons({ onGenerate }: { onGenerate: () => void }) {
   return (
@@ -167,6 +168,7 @@ function AppInner() {
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
       <h1 className="text-2xl font-semibold">Codex Session Viewer</h1>
       <p className="text-gray-600">Vite + React + TS + Tailwind + Headless UI</p>
+      <ThemePicker />
 
       <button
         className="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500 transition"

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,0 +1,37 @@
+import { useTheme } from '../state/theme'
+
+const themes = ['teal', 'rose', 'indigo'] as const
+const modes = ['light', 'dark', 'system'] as const
+
+export default function ThemePicker() {
+  const { theme, mode, setTheme, setMode } = useTheme()
+
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-sm">Theme</label>
+      <select
+        className="border rounded px-2 py-1 text-sm bg-background text-foreground"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as any)}
+      >
+        {themes.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <label className="text-sm ml-4">Mode</label>
+      <select
+        className="border rounded px-2 py-1 text-sm bg-background text-foreground"
+        value={mode}
+        onChange={(e) => setMode(e.target.value as any)}
+      >
+        {modes.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
 @import 'tailwindcss';
+@import './theme.css';
 
 /* App-level tweaks can go here */

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -48,15 +48,29 @@ export function parseResponseItemLine(line: string): SafeResult<ResponseItemPars
   // Preserve base fields when available, and tuck the original payload under `data`.
   if (isRecord(j.data)) {
     const base = j.data
-    const fallback = {
-      type: 'Other',
-      id: typeof base.id === 'string' ? base.id : undefined,
-      at: typeof base.at === 'string' ? base.at : undefined,
-      index: typeof base.index === 'number' ? base.index : undefined,
-      data: base,
+    const t = typeof (base as any).type === 'string' ? (base as any).type : undefined
+    const known = [
+      'Message',
+      'Reasoning',
+      'FunctionCall',
+      'LocalShellCall',
+      'WebSearchCall',
+      'CustomToolCall',
+      'FileChange',
+      'Other',
+    ]
+    // Only coerce to Other when type is missing or unknown
+    if (!t || !known.includes(t)) {
+      const fallback = {
+        type: 'Other',
+        id: typeof base.id === 'string' ? base.id : undefined,
+        at: typeof base.at === 'string' ? base.at : undefined,
+        index: typeof base.index === 'number' ? base.index : undefined,
+        data: base,
+      }
+      const alt = ResponseItemSchema.safeParse(fallback)
+      if (alt.success) return { success: true, data: alt.data }
     }
-    const alt = ResponseItemSchema.safeParse(fallback)
-    if (alt.success) return { success: true, data: alt.data }
   }
 
   return { success: false, error: res.error, reason: 'invalid_schema' }
@@ -109,8 +123,10 @@ function normalizeForeignEventShape(data: Record<string, unknown>): Record<strin
 
   switch (t) {
     case 'message': {
+      if ((base as any).content == null) return null
       const role = typeof base.role === 'string' ? base.role : 'assistant'
-      const content = flattenContent((base as any).content) ?? ''
+      const content = flattenContent((base as any).content)
+      if (content == null) return null
       const model = typeof (base as any).model === 'string' ? (base as any).model : undefined
       return { type: 'Message', role, content, model, id: base.id, at: base.at, index: base.index }
     }

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type Mode = 'light' | 'dark' | 'system'
+type Theme = 'teal' | 'rose' | 'indigo'
+
+interface ThemeState {
+  theme: Theme
+  mode: Mode
+  setTheme: (t: Theme) => void
+  setMode: (m: Mode) => void
+}
+
+const applyTheme = (theme: Theme) => {
+  document.documentElement.setAttribute('data-theme', theme)
+}
+
+const applyMode = (mode: Mode) => {
+  const root = document.documentElement
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
+  const isDark = mode === 'dark' || (mode === 'system' && prefersDark.matches)
+  root.classList.toggle('dark', isDark)
+  root.setAttribute('data-mode', isDark ? 'dark' : 'light')
+}
+
+export const useTheme = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: 'teal',
+      mode: 'system',
+      setTheme: (theme) => {
+        applyTheme(theme)
+        set({ theme })
+      },
+      setMode: (mode) => {
+        applyMode(mode)
+        set({ mode })
+      }
+    }),
+    {
+      name: 'csv:theme',
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          applyTheme(state.theme)
+          applyMode(state.mode)
+        }
+      }
+    }
+  )
+)
+
+// Apply initial state
+applyTheme(useTheme.getState().theme)
+applyMode(useTheme.getState().mode)
+
+// React to system preference changes when in system mode
+const media = window.matchMedia('(prefers-color-scheme: dark)')
+media.addEventListener('change', () => {
+  const { mode } = useTheme.getState()
+  if (mode === 'system') applyMode('system')
+})

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,21 @@
+:root {
+  --background: 255 255 255;
+  --foreground: 0 0 0;
+  --primary: 13 148 136; /* teal */
+  --primary-foreground: 255 255 255;
+}
+
+[data-mode='dark'] {
+  --background: 15 23 42;
+  --foreground: 255 255 255;
+}
+
+[data-theme='teal'] {
+  --primary: 13 148 136;
+}
+[data-theme='rose'] {
+  --primary: 244 63 94;
+}
+[data-theme='indigo'] {
+  --primary: 79 70 229;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'rgb(var(--background) / <alpha-value>)',
+        foreground: 'rgb(var(--foreground) / <alpha-value>)',
+        primary: 'rgb(var(--primary) / <alpha-value>)',
+        'primary-foreground': 'rgb(var(--primary-foreground) / <alpha-value>)'
+      }
+    }
+  },
+  plugins: []
+}
+
+export default config


### PR DESCRIPTION
## Summary
- define CSS variables and tokens for tailwind theme
- persist theme and mode in a Zustand store with localStorage
- add ThemePicker component and integrate it into the app
- ensure invalid response items don't coerce to "Other" and require message content

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0587e97a08328a7e38845658d7a24