### PR TITLE
refactor: replace emojis with icons and unify palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Diff Viewer
 Themes and Editor Theme
 -----------------------
 
-- Theme: Use the Theme picker (top of the page) to choose a color theme (`teal`, `rose`, `indigo`) and Mode (`light`, `dark`, `system`). The app persists your choice and honors system dark mode when `system` is selected.
+- Theme: Use the Theme picker (top of the page) to choose the `slate` theme and Mode (`light`, `dark`, `system`). The app persists your choice and honors system dark mode when `system` is selected.
 - Contrast guard: If primary/text contrast falls below recommended thresholds, an inline warning appears near the picker.
 - Diff Viewer editor theme: Each Diff Viewer instance has a small selector (auto/light/dark). `auto` tracks the app mode; `light`/`dark` override the Monaco editor theme for that view only.
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Codex Session Viewer</title>
   </head>
-  <body class="min-h-screen bg-gray-50 text-gray-900">
+  <body class="min-h-screen bg-white text-gray-900 antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { matchesEvent } from './utils/search'
 import ExportModal from './components/ExportModal'
 import ThemePicker from './components/ThemePicker'
 import { containsApplyPatchAnywhere } from './utils/applyPatchHints'
+import { CircleIcon, ChevronDownIcon, XIcon } from './components/ui/icons'
 
 function DevButtons({ onGenerate }: { onGenerate: () => void }) {
   return (
@@ -264,7 +265,7 @@ function AppInner() {
       <ThemePicker />
 
       <button
-        className="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-500 transition"
+        className="px-3 py-2 rounded bg-gray-900 text-white hover:bg-gray-800 transition"
         onClick={() => setCount((c) => c + 1)}
       >
         Clicked {count} times
@@ -275,12 +276,10 @@ function AppInner() {
           <div className="space-y-2">
             <Disclosure.Button className="flex items-center gap-2 px-3 py-2 rounded bg-white shadow hover:shadow-md transition">
               <span>What is this app?</span>
-              <span
-                className="text-indigo-600 transition"
+              <ChevronDownIcon
+                className="text-gray-600 transition"
                 style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
-              >
-                ▾
-              </span>
+              />
             </Disclosure.Button>
             <Disclosure.Panel className="p-3 text-sm text-gray-700 bg-white rounded shadow space-y-2">
               <p>A viewer for Codex CLI sessions. Now includes streaming parser, metadata, and a virtualized timeline.</p>
@@ -380,7 +379,9 @@ function AppInner() {
                       await handleFile(file)
                     }}
                   >
-                  {(idx + 1) + '. '} {item.path.split('/').slice(-1)[0]} {chipMarks[item.path] && <span className="ml-1 text-emerald-600" title="Content match">●</span>}
+                  {(idx + 1) + '. '} {item.path.split('/').slice(-1)[0]} {chipMarks[item.path] && (
+                    <CircleIcon className="ml-1 text-gray-500 h-2 w-2" />
+                  )}
                 </Button>
                 )})
               })()}
@@ -416,7 +417,7 @@ function AppInner() {
         )}
 
         {loader.state.phase === 'parsing' && (
-          <p className="text-sm text-indigo-700">Parsing… ok {loader.progress.ok}, errors {loader.progress.fail}</p>
+          <p className="text-sm text-gray-600">Parsing… ok {loader.progress.ok}, errors {loader.progress.fail}</p>
         )}
         {loader.state.phase === 'success' && (
           <div className="text-sm text-green-700">
@@ -565,7 +566,7 @@ function AppInner() {
                     <select
                       value={typeFilter}
                       onChange={(e) => setTypeFilter(e.target.value as TypeFilter)}
-                      className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                      className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
                       aria-label="Filter by event type"
                     >
                       {TYPE_OPTIONS.map((t) => (
@@ -649,7 +650,7 @@ function AppInner() {
                         // Ensure role filter is effective by switching to Message when needed
                         if (next !== 'All' && typeFilter !== 'Message') setTypeFilter('Message')
                       }}
-                      className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                      className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
                       aria-label="Filter message role"
                       title={typeFilter !== 'Message' && roleFilter !== 'All' ? 'Role filter applies to Message events' : undefined}
                     >
@@ -668,13 +669,13 @@ function AppInner() {
                 placeholder="Search events…"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
                 aria-label="Search events"
               />
               <div className="relative">
                 <details className="[&_summary::-webkit-details-marker]:hidden">
-                  <summary className="h-9 px-3 text-sm leading-5 border rounded-md cursor-pointer select-none flex items-center gap-2 bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700">
-                    Advanced filters ▾
+                  <summary className="h-9 px-3 text-sm leading-5 border rounded-md cursor-pointer select-none flex items-center gap-1 bg-gray-100 border-gray-300 text-gray-800 hover:bg-gray-200">
+                    Advanced filters <ChevronDownIcon className="h-4 w-4" />
                   </summary>
                   <div className="absolute left-0 z-10 mt-1 w-[24rem] max-w-[95vw] rounded-md border bg-white shadow p-3">
                     <div className="mb-2 text-xs font-semibold text-gray-600">Advanced filters</div>
@@ -684,7 +685,7 @@ function AppInner() {
                         placeholder="Path filter (e.g., src/ or app.tsx)"
                         value={pathFilter}
                         onChange={(e) => setPathFilter(e.target.value)}
-                        className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                        className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
                         aria-label="Filter by file path"
                       />
                       <Button
@@ -741,7 +742,7 @@ function AppInner() {
                   <summary
                     className={
                       `h-9 px-3 text-sm leading-5 rounded-md cursor-pointer select-none ${
-                        loader.state.events.length ? 'bg-teal-600 text-white hover:bg-teal-500' : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                        loader.state.events.length ? 'bg-gray-900 text-white hover:bg-gray-800' : 'bg-gray-700 text-gray-400 cursor-not-allowed'
                       }`
                     }
                     aria-disabled={!loader.state.events.length}
@@ -786,7 +787,7 @@ function AppInner() {
                         aria-label={`Clear ${c.key}`}
                         onClick={c.onClear}
                       >
-                        ×
+                        <XIcon className="h-3 w-3" />
                       </button>
                     </Badge>
                   ))}

--- a/src/components/ApplyPatchView.tsx
+++ b/src/components/ApplyPatchView.tsx
@@ -5,6 +5,7 @@ import { parseUnifiedDiffToSides } from '../utils/diff'
 import { extractApplyPatchText, parseApplyPatch } from '../parsers/applyPatch'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
+import { CircleIcon } from './ui/icons'
 
 export interface ApplyPatchViewProps {
   item: Extract<ResponseItem, { type: 'FunctionCall' }>
@@ -38,7 +39,13 @@ export default function ApplyPatchView({ item, pairedResultMeta }: ApplyPatchVie
         {typeof item.durationMs === 'number' && <span className="text-gray-400">{item.durationMs} ms</span>}
         {status && (
           <Badge variant={status.exitCode === 0 ? 'secondary' : 'destructive'}>
-            {status.exitCode === 0 ? 'success' : `exit ${status.exitCode}`} {status.duration != null && `• ${status.duration}s`}
+            {status.exitCode === 0 ? 'success' : `exit ${status.exitCode}`}
+            {status.duration != null && (
+              <>
+                <CircleIcon className="inline-block mx-1 h-1.5 w-1.5" />
+                {status.duration}s
+              </>
+            )}
           </Badge>
         )}
         <span className="text-gray-400">files: {ops.length}</span>

--- a/src/components/CommandsView.tsx
+++ b/src/components/CommandsView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { ResponseItem } from '../types'
 import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
 import { Button } from './ui/button'
+import { ChevronDownIcon } from './ui/icons'
 import { downloadText } from '../utils/download'
 
 export interface CommandRow {
@@ -85,13 +86,13 @@ export function CommandsView({
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search commands…"
-            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
             aria-label="Search commands"
           />
           <select
             value={exit}
             onChange={(e) => setExit(e.target.value as any)}
-            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
             aria-label="Exit code filter"
           >
             {(['All', 'Success', 'Failed'] as const).map((t) => (
@@ -102,7 +103,7 @@ export function CommandsView({
             value={minMs}
             onChange={(e) => setMinMs(e.target.value)}
             placeholder="Min ms"
-            className="h-9 px-3 text-sm leading-5 border rounded-md w-28 bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="h-9 px-3 text-sm leading-5 border rounded-md w-28 bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
             aria-label="Min duration in ms"
             inputMode="numeric"
             pattern="[0-9]*"
@@ -110,7 +111,9 @@ export function CommandsView({
           <Button variant="outline" size="default" onClick={() => { setQ(''); setExit('All'); setMinMs('') }}>Clear</Button>
           <div className="relative">
             <details className="[&_summary::-webkit-details-marker]:hidden">
-              <summary className="h-9 px-3 text-sm leading-5 rounded-md cursor-pointer select-none bg-teal-600 text-white hover:bg-teal-500">Export ▾</summary>
+              <summary className="h-9 px-3 text-sm leading-5 rounded-md cursor-pointer select-none bg-gray-800 text-white hover:bg-gray-700 flex items-center gap-1">
+                Export <ChevronDownIcon className="h-4 w-4" />
+              </summary>
               <div className="absolute right-0 z-10 mt-1 w-44 rounded-md border bg-white shadow">
                 <button className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" onClick={exportCsv}>CSV</button>
                 <button className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50" onClick={exportJson}>JSON</button>

--- a/src/components/DropZone.tsx
+++ b/src/components/DropZone.tsx
@@ -47,7 +47,7 @@ export function DropZone({ onFile, acceptExtensions = ['.jsonl', '.txt'], classN
           onDrop={onDrop}
           className={
             `m-2 border-2 border-dashed rounded p-6 text-center transition ${
-              isOver ? 'border-indigo-600 bg-indigo-50' : 'border-gray-300'
+              isOver ? 'border-gray-600 bg-gray-100' : 'border-gray-300'
             }`
           }
         >

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -3,7 +3,7 @@ import type { ResponseItem } from '../types'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './ui/card'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
-import { ClipboardIcon, StarFilledIcon, StarIcon } from './ui/icons'
+import { ClipboardIcon, StarFilledIcon, StarIcon, PlusIcon } from './ui/icons'
 import { useBookmarks } from '../state/bookmarks'
 import { eventKey as computeEventKey } from '../utils/eventKey'
 import { containsApplyPatchAnywhere } from '../utils/applyPatchHints'
@@ -204,7 +204,7 @@ function WebSearchCallView({ item }: { item: Extract<ResponseItem, { type: 'WebS
           {item.results.slice(0, 10).map((r, i) => (
             <li key={i} className="text-sm">
               {r.url ? (
-                <a className="text-indigo-600 hover:underline" href={r.url} target="_blank" rel="noreferrer noopener">
+                <a className="text-gray-600 hover:underline" href={r.url} target="_blank" rel="noreferrer noopener">
                   {r.title || r.url}
                 </a>
               ) : (
@@ -259,7 +259,11 @@ export default function EventCard({ item, index, bookmarkKey, onRevealFile, onOp
         {typeof index === 'number' && <div className="text-xs text-gray-500">#{index + 1}</div>}
         {at && <div className="text-xs text-gray-500">{formatAt(at)}</div>}
         {has(key) && <Badge variant="secondary">Bookmarked</Badge>}
-        {containsApplyPatchAnywhere(item) && <Badge variant="outline" title="This event references apply_patch">✚ apply_patch</Badge>}
+        {containsApplyPatchAnywhere(item) && (
+          <Badge variant="outline" title="This event references apply_patch">
+            <PlusIcon className="h-3 w-3" /> apply_patch
+          </Badge>
+        )}
       </CardHeader>
       <CardContent>
         {item.type === 'Message' && <MessageEventView item={item} highlight={highlight} />}

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -54,7 +54,7 @@ export default function ExportModal({ open, onClose, meta, items, filters, defau
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <label className="text-sm w-24">Format</label>
-              <select value={format} onChange={(e) => setFormat(e.target.value as any)} className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500">
+              <select value={format} onChange={(e) => setFormat(e.target.value as any)} className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500">
                 <option value="csv">CSV</option>
                 <option value="json">JSON</option>
                 <option value="markdown">Markdown</option>

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -98,7 +98,7 @@ function TreeNodes({
             ref={(el) => itemRefs.current.set(n.path, el)}
             className={cn(
               'flex items-center gap-1 py-0.5 px-1 rounded hover:bg-gray-50 cursor-pointer',
-              selectedPath === n.path && 'bg-indigo-50 text-indigo-700',
+              selectedPath === n.path && 'bg-gray-100 text-gray-700',
             )}
             style={{ paddingLeft: 8 + depth * 14 }}
             onClick={() => {

--- a/src/components/SessionsList.tsx
+++ b/src/components/SessionsList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { DiscoveredSessionAsset } from '../hooks/useAutoDiscovery'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { Button } from './ui/button'
+import { CircleIcon } from './ui/icons'
 import { parseTimestampFromPath } from '../utils/timestamp'
 
 export interface SessionsListProps {
@@ -96,7 +97,7 @@ export default function SessionsList({ sessions, onSelect, onClose, onReload, lo
               value={scanQuery}
               onChange={(e) => setScanQuery(e.target.value)}
               placeholder="Content filter (e.g., apply_patch)"
-              className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500 w-56"
+            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 w-56"
               title="Fetch sessions and mark those whose content contains this text"
             />
             <Button
@@ -131,7 +132,7 @@ export default function SessionsList({ sessions, onSelect, onClose, onReload, lo
             )}
           </div>
           <select
-            className="h-9 px-2 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            className="h-9 px-2 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
             value={sort}
             onChange={(e) => setSort(e.target.value as any)}
             title="Sort order"
@@ -144,7 +145,7 @@ export default function SessionsList({ sessions, onSelect, onClose, onReload, lo
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search by path…"
-            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-teal-500 w-64"
+            className="h-9 px-3 text-sm leading-5 border rounded-md bg-gray-800 border-gray-700 text-gray-100 placeholder-gray-400 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 w-64"
           />
           {onClose && (
             <Button variant="outline" size="sm" onClick={onClose}>Close</Button>
@@ -173,7 +174,7 @@ export default function SessionsList({ sessions, onSelect, onClose, onReload, lo
             <div className="max-h-[50vh] overflow-auto">
               {matches.length > 0 && (
                 <div>
-                  <div className="px-2 py-1 text-xs font-semibold text-emerald-700 bg-emerald-50 sticky top-0">Matches ({matches.length})</div>
+                <div className="px-2 py-1 text-xs font-semibold text-gray-700 bg-gray-100 sticky top-0">Matches ({matches.length})</div>
                   <div className="divide-y">
                     {matches.map((s) => (
                       <Row key={s.path} s={s} mark={true} busy={busy} onLoad={handleLoad} />
@@ -204,7 +205,8 @@ function Row({ s, mark, busy, onLoad }: { s: DiscoveredSessionAsset; mark: boole
     <div className="py-2 flex items-center gap-2 justify-between">
       <div className="min-w-0 flex-1">
         <div className="text-sm truncate" title={s.path}>
-          {s.path} {mark && <span title="Content match" className="ml-1 text-emerald-600">●</span>}
+          {s.path}{' '}
+          {mark && <CircleIcon className="ml-1 text-gray-500 h-2 w-2" />}
         </div>
       </div>
       <div className="flex gap-2 shrink-0">

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTheme } from '../state/theme'
 
-const themes = ['teal', 'rose', 'indigo'] as const
+const themes = ['slate'] as const
 const modes = ['light', 'dark', 'system'] as const
 
 function parseRGBTriplet(s: string): [number, number, number] | null {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -3,15 +3,13 @@ import { cn } from '../../utils/cn'
 
 type Variant = 'default' | 'secondary' | 'destructive' | 'outline'
 
-const base = 'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium'
+const base = 'inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium'
 
 const variants: Record<Variant, string> = {
-  // Active chip: filled accent
-  default: 'border-transparent bg-teal-600 text-white',
-  // Neutral chip: subtle border only
-  secondary: 'border-gray-600 text-gray-200',
+  default: 'border-transparent bg-gray-800 text-white',
+  secondary: 'border-gray-300 text-gray-700',
   destructive: 'border-transparent bg-red-600 text-white',
-  outline: 'border-gray-600 text-gray-200'
+  outline: 'border-gray-300 text-gray-700'
 }
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,15 +5,15 @@ type Variant = 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | '
 type Size = 'default' | 'sm' | 'lg' | 'icon'
 
 const base =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 disabled:pointer-events-none disabled:opacity-50'
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 disabled:pointer-events-none disabled:opacity-50'
 
 const variants: Record<Variant, string> = {
-  default: 'bg-teal-600 text-white hover:bg-teal-500',
-  secondary: 'bg-gray-700 text-gray-100 hover:bg-gray-600',
+  default: 'bg-gray-900 text-white hover:bg-gray-800',
+  secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
   destructive: 'bg-red-600 text-white hover:bg-red-500',
-  outline: 'border border-gray-600 bg-transparent hover:bg-gray-800 text-gray-100',
-  ghost: 'bg-transparent hover:bg-gray-800 text-gray-100',
-  link: 'bg-transparent text-teal-400 underline-offset-4 hover:underline'
+  outline: 'border border-gray-300 bg-transparent hover:bg-gray-100 text-gray-900',
+  ghost: 'bg-transparent hover:bg-gray-100 text-gray-900',
+  link: 'bg-transparent text-gray-900 underline-offset-4 hover:underline'
 }
 
 const sizes: Record<Size, string> = {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { cn } from '../../utils/cn'
 
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('rounded-lg border border-gray-800 bg-gray-900 text-gray-100 shadow-sm', className)} {...props} />
+  return <div className={cn('rounded-lg border border-gray-200 bg-white text-gray-900 shadow-sm', className)} {...props} />
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
@@ -10,11 +10,11 @@ export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn('text-base font-semibold leading-none tracking-tight text-gray-100', className)} {...props} />
+  return <h3 className={cn('text-base font-semibold leading-none tracking-tight text-gray-900', className)} {...props} />
 }
 
 export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn('text-sm text-gray-400', className)} {...props} />
+  return <p className={cn('text-sm text-gray-500', className)} {...props} />
 }
 
 export function CardAction({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -58,3 +58,66 @@ export function ClipboardIcon({ size = 16, ...props }: IconProps) {
   )
 }
 
+export function PlusIcon({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function CircleIcon({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  )
+}
+
+export function ChevronDownIcon({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function XIcon({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M6 6l12 12M6 18L18 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 type Mode = 'light' | 'dark' | 'system'
-type Theme = 'teal' | 'rose' | 'indigo'
+type Theme = 'slate'
 
 interface ThemeState {
   theme: Theme
@@ -26,7 +26,7 @@ const applyMode = (mode: Mode) => {
 export const useTheme = create<ThemeState>()(
   persist(
     (set) => ({
-      theme: 'teal',
+      theme: 'slate',
       mode: 'system',
       setTheme: (theme) => {
         applyTheme(theme)

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,21 +1,17 @@
 :root {
   --background: 255 255 255;
-  --foreground: 0 0 0;
-  --primary: 13 148 136; /* teal */
+  --foreground: 17 24 39;
+  --primary: 31 41 55;
   --primary-foreground: 255 255 255;
 }
 
 [data-mode='dark'] {
-  --background: 15 23 42;
+  --background: 17 24 39;
   --foreground: 255 255 255;
+  --primary: 243 244 246;
+  --primary-foreground: 17 24 39;
 }
 
-[data-theme='teal'] {
-  --primary: 13 148 136;
-}
-[data-theme='rose'] {
-  --primary: 244 63 94;
-}
-[data-theme='indigo'] {
-  --primary: 79 70 229;
+[data-theme='slate'] {
+  --primary: 31 41 55;
 }


### PR DESCRIPTION
## Summary
- replace ad-hoc emoji glyphs with reusable SVG icons
- adopt neutral slate palette and simplify theme picker
- refine component spacing and button/badge styles for cleaner layout

## Testing
- `npm run typecheck`
- `npm test` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c17f7205908328a948c8d15871bf75