### PR TITLE
Add edge case tests for utility helpers

### DIFF
--- a/src/utils/__tests__/applyPatchHints.test.ts
+++ b/src/utils/__tests__/applyPatchHints.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { containsApplyPatchAnywhere } from '../applyPatchHints'
+
+describe('applyPatchHints', () => {
+  it('detects nested apply_patch occurrences', () => {
+    const ev = {
+      args: {
+        layers: [
+          { message: 'no patch here' },
+          { deeper: { text: 'something apply_patch inside' } },
+        ],
+      },
+    }
+    expect(containsApplyPatchAnywhere(ev)).toBe(true)
+  })
+
+  it('returns false when apply_patch is absent', () => {
+    const ev = { args: { nested: [{ msg: 'hello' }] } }
+    expect(containsApplyPatchAnywhere(ev)).toBe(false)
+  })
+
+  it('handles null or primitive inputs gracefully', () => {
+    expect(containsApplyPatchAnywhere(null)).toBe(false)
+    expect(containsApplyPatchAnywhere(undefined)).toBe(false)
+  })
+})
+

--- a/src/utils/__tests__/search.test.ts
+++ b/src/utils/__tests__/search.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { matchesEvent, normalize } from '../search'
+import type { ResponseItem } from '../../types'
+
+describe('search utilities', () => {
+  it('normalizes query', () => {
+    expect(normalize('  FoO ')).toBe('foo')
+  })
+
+  it('matches text within events', () => {
+    const ev: ResponseItem = { type: 'Message', role: 'user', content: 'Hello World' }
+    expect(matchesEvent(ev, 'hello')).toBe(true)
+    expect(matchesEvent(ev, 'WORLD')).toBe(true)
+    expect(matchesEvent(ev, 'missing')).toBe(false)
+  })
+
+  it('matches file paths in FileChange events', () => {
+    const ev: ResponseItem = { type: 'FileChange', path: 'src/utils/applyPatchHints.ts', diff: '' }
+    expect(matchesEvent(ev, 'applypatchhints')).toBe(true)
+    expect(matchesEvent(ev, 'UTILS')).toBe(true)
+    expect(matchesEvent(ev, 'unknown')).toBe(false)
+  })
+
+  it('returns true for empty query', () => {
+    const ev: ResponseItem = { type: 'Message', role: 'user', content: 'anything' }
+    expect(matchesEvent(ev, '')).toBe(true)
+    expect(matchesEvent(ev, '   ')).toBe(true)
+  })
+})
+


### PR DESCRIPTION
## Summary
- Add tests for `containsApplyPatchAnywhere` covering nested apply_patch strings and invalid inputs
- Extend search utility tests to cover normalization, event text matching, file path matching, and empty queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c20ca312848328a6928a8b0e063dfe