### PR TITLE
Handle legacy arguments field for function_call

### DIFF
--- a/src/parser/__tests__/validators.test.ts
+++ b/src/parser/__tests__/validators.test.ts
@@ -27,4 +27,14 @@ describe('validators', () => {
     expect(bad.success).toBe(false)
     if (!bad.success) expect(bad.reason).toBe('invalid_schema')
   })
+
+  it('parses function_call events with arguments field', () => {
+    const line = JSON.stringify({ type: 'function_call', name: 'sum', arguments: { a: 1, b: 2 } })
+    const res = parseResponseItemLine(line)
+    expect(res.success).toBe(true)
+    if (res.success) {
+      expect(res.data.type).toBe('FunctionCall')
+      expect(res.data.args).toEqual({ a: 1, b: 2 })
+    }
+  })
 })

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -240,7 +240,7 @@ function normalizeForeignEventShape(data: Record<string, unknown>): Record<strin
       return {
         type: 'FunctionCall',
         name: asString((base as any).tool) ?? asString((base as any).name) ?? 'tool',
-        args: (base as any).args,
+        args: (base as any).args ?? (base as any).arguments,
         result: (base as any).output ?? (base as any).result,
         id: base.id, at: base.at, index: base.index,
       }


### PR DESCRIPTION
## Summary
- map `arguments` to `args` when normalizing `function_call` events
- cover `function_call` events with `arguments` in validators tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a24580048328a7e3c60568254d9b