### PR TITLE
Handle missing reasoning content

### DIFF
--- a/src/parser/__tests__/reasoning.test.ts
+++ b/src/parser/__tests__/reasoning.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { parseResponseItemLine } from '../validators'
+
+describe('reasoning content fallbacks', () => {
+  it('uses summary when content is empty', () => {
+    const line = JSON.stringify({ type: 'reasoning', content: '', summary: 'fallback summary' })
+    const res = parseResponseItemLine(line)
+    expect(res.success).toBe(true)
+    if (res.success) {
+      const ev = res.data as any
+      expect(ev.type).toBe('Reasoning')
+      expect(ev.content).toBe('fallback summary')
+    }
+  })
+
+  it('surfaces [encrypted] when only encrypted_content exists', () => {
+    const line = JSON.stringify({ type: 'reasoning', encrypted_content: 'deadbeef' })
+    const res = parseResponseItemLine(line)
+    expect(res.success).toBe(true)
+    if (res.success) {
+      const ev = res.data as any
+      expect(ev.type).toBe('Reasoning')
+      expect(ev.content).toBe('[encrypted]')
+    }
+  })
+})

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -166,6 +166,15 @@ function flattenContent(content: unknown): string | undefined {
   return asString(content)
 }
 
+function extractReasoningContent(src: Record<string, any>): string | null {
+  let content = flattenContent(src.content)
+  if (typeof content === 'string' && content.trim() !== '') return content
+  const summary = flattenContent(src.summary)
+  if (typeof summary === 'string' && summary.trim() !== '') return summary
+  if ('encryptedContent' in src) return '[encrypted]'
+  return null
+}
+
 function tryParseJsonText(s?: string): unknown {
   if (!s) return undefined
   try { return JSON.parse(s) } catch { return s }
@@ -219,8 +228,12 @@ function normalizeForeignEventShape(data: Record<string, unknown>): Record<strin
   switch (t) {
     // Codex CLI event_msg subtypes
     case 'agent_reasoning': {
-      const content = flattenContent((base as any).text ?? (base as any).content)
-      if (content === undefined) return null
+      const content = extractReasoningContent({
+        content: (base as any).text ?? (base as any).content,
+        summary: (base as any).summary,
+        encryptedContent: (base as any).encryptedContent,
+      })
+      if (content == null) return null
       return { type: 'Reasoning', content, id: base.id, at: base.at, index: base.index }
     }
     case 'agent_message': {
@@ -278,8 +291,8 @@ function normalizeForeignEventShape(data: Record<string, unknown>): Record<strin
       return { type: 'Message', role, content, model, id: base.id, at: base.at, index: base.index }
     }
     case 'reasoning': {
-      const content = flattenContent((base as any).content)
-      if (content === undefined) return null
+      const content = extractReasoningContent(base as any)
+      if (content == null) return null
       return { type: 'Reasoning', content, id: base.id, at: base.at, index: base.index }
     }
     // Removed duplicate function_call / function_call_output cases (handled above)

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -19,6 +19,8 @@ export interface MessageEvent extends BaseEvent {
 
 /**
  * Model reasoning trace (if available). Content is plain text/markdown.
+ * If `content` is empty, a flattened `summary` is used instead.
+ * When only encrypted content is present, the placeholder `[encrypted]` is surfaced.
  */
 export interface ReasoningEvent extends BaseEvent {
   readonly type: 'Reasoning'


### PR DESCRIPTION
## Summary
- ensure reasoning events fall back to summary text or `[encrypted]` placeholder when content is missing
- document reasoning content fallbacks in `ReasoningEvent`
- test reasoning parser behavior for summary and encrypted content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a24763048328949adab845c6d7ee