### PR TITLE
feat: allow structured message content

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -41,6 +41,9 @@ function Highlight({ text, query }: { text: string; query?: string }) {
 }
 
 function MessageEventView({ item, highlight }: { item: Extract<ResponseItem, { type: 'Message' }> ; highlight?: string }) {
+  const text = typeof item.content === 'string'
+    ? item.content
+    : item.content.map((p) => ('text' in p ? String((p as any).text) : '')).join('\n')
   return (
     <div className="space-y-2">
       <div className="text-xs text-gray-500 flex flex-wrap gap-2 items-center">
@@ -48,7 +51,7 @@ function MessageEventView({ item, highlight }: { item: Extract<ResponseItem, { t
         {item.model && <span className="text-gray-400">{item.model}</span>}
       </div>
       <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2 max-h-64 overflow-auto">
-        <Highlight text={item.content} query={highlight} />
+        <Highlight text={text} query={highlight} />
       </pre>
     </div>
   )

--- a/src/export/columns.ts
+++ b/src/export/columns.ts
@@ -18,7 +18,11 @@ export const COLUMN_CATALOG: ColumnMeta[] = [
   { key: 'path', label: 'path', type: 'string', extractor: (ev: any) => ev.path },
   { key: 'command', label: 'command', type: 'string', extractor: (ev: any) => ev.command },
   { key: 'name', label: 'name', type: 'string', extractor: (ev: any) => ev.name },
-  { key: 'content', label: 'content', type: 'string', extractor: (ev: any) => (typeof ev.content === 'string' ? ev.content : undefined) },
+  { key: 'content', label: 'content', type: 'string', extractor: (ev: any) => (typeof ev.content === 'string'
+      ? ev.content
+      : Array.isArray(ev.content)
+        ? ev.content.map((p: any) => ('text' in p ? String(p.text) : '')).join('\n')
+        : undefined) },
   { key: 'diff', label: 'diff', type: 'string', extractor: (ev: any) => (typeof ev.diff === 'string' ? ev.diff : undefined) },
   { key: 'args', label: 'args', type: 'json', extractor: (ev: any) => ev.args },
   { key: 'result', label: 'result', type: 'json', extractor: (ev: any) => ev.result },

--- a/src/export/csv.ts
+++ b/src/export/csv.ts
@@ -18,7 +18,11 @@ export const defaultCsvFields: CsvField[] = [
   {
     key: 'content',
     label: 'content',
-    extractor: (ev: any) => (typeof ev.content === 'string' ? ev.content : undefined),
+    extractor: (ev: any) => (typeof ev.content === 'string'
+      ? ev.content
+      : Array.isArray(ev.content)
+        ? ev.content.map((p: any) => ('text' in p ? String(p.text) : '')).join('\n')
+        : undefined),
   },
   {
     key: 'diff',

--- a/src/parser/__tests__/foreignWrappers.test.ts
+++ b/src/parser/__tests__/foreignWrappers.test.ts
@@ -72,7 +72,9 @@ describe('foreign wrappers and blanks', () => {
     if (r.success) {
       expect((r.data as any).type).toBe('Message')
       expect((r.data as any).role).toBe('user')
-      expect((r.data as any).content).toContain('hello world')
+      const c = (r.data as any).content
+      expect(Array.isArray(c)).toBe(true)
+      if (Array.isArray(c)) expect(c[0].text).toBe('hello world')
     }
   })
 

--- a/src/parser/__tests__/validators.test.ts
+++ b/src/parser/__tests__/validators.test.ts
@@ -3,6 +3,7 @@ import { parseSessionMetaLine, parseResponseItemLine } from '../../parser/valida
 
 const metaOk = JSON.stringify({ id: 's1', timestamp: '2025-01-01T00:00:00Z', version: 1 })
 const msgOk = JSON.stringify({ type: 'Message', role: 'user', content: 'hi' })
+const msgArr = JSON.stringify({ type: 'Message', role: 'assistant', content: [{ type: 'text', text: 'hello' }] })
 
 describe('validators', () => {
   it('parses valid meta', () => {
@@ -26,5 +27,15 @@ describe('validators', () => {
     const bad = parseResponseItemLine(JSON.stringify({ type: 'Message', role: 'user' }))
     expect(bad.success).toBe(false)
     if (!bad.success) expect(bad.reason).toBe('invalid_schema')
+  })
+
+  it('parses message content arrays', () => {
+    const res = parseResponseItemLine(msgArr)
+    expect(res.success).toBe(true)
+    if (res.success) {
+      expect(Array.isArray(res.data.content)).toBe(true)
+      const arr = res.data.content as any
+      expect(arr[0].text).toBe('hello')
+    }
   })
 })

--- a/src/parser/schemas.ts
+++ b/src/parser/schemas.ts
@@ -28,7 +28,10 @@ const BaseEvent = z.object({
 const MessageEventSchema = BaseEvent.extend({
   type: z.literal('Message'),
   role: z.string(),
-  content: z.string(),
+  content: z.union([
+    z.string(),
+    z.array(z.object({ type: z.string(), text: z.string() }).passthrough()),
+  ]),
   model: z.string().optional(),
 })
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -8,12 +8,21 @@ export interface BaseEvent {
 }
 
 /**
+ * Segment of a structured message content array.
+ */
+export interface MessagePart {
+  readonly type: string
+  readonly text: string
+  readonly [key: string]: unknown
+}
+
+/**
  * Message emitted by user/assistant/system.
  */
 export interface MessageEvent extends BaseEvent {
   readonly type: 'Message'
   readonly role: 'user' | 'assistant' | 'system' | string
-  readonly content: string
+  readonly content: string | ReadonlyArray<MessagePart>
   readonly model?: string
 }
 

--- a/src/utils/exporters.ts
+++ b/src/utils/exporters.ts
@@ -32,9 +32,13 @@ export function toMarkdown(meta: ParsedSession['meta'] | undefined, events: read
     const anyEv = ev as any
     lines.push('', `### ${idx + 1}. ${anyEv.type}${anyEv.at ? ` — ${anyEv.at}` : ''}`)
     switch (ev.type) {
-      case 'Message':
-        lines.push(`- role: ${ev.role}`, '```', ev.content, '```')
+      case 'Message': {
+        const content = typeof ev.content === 'string'
+          ? ev.content
+          : ev.content.map((p) => ('text' in p ? String((p as any).text) : '')).join('\n')
+        lines.push(`- role: ${ev.role}`, '```', content, '```')
         break
+      }
       case 'Reasoning':
         lines.push('```', ev.content, '```')
         break
@@ -135,10 +139,14 @@ export function toHtml(meta: ParsedSession['meta'] | undefined, events: readonly
     const at = anyEv.at ? ` — ${esc(String(anyEv.at))}` : ''
     lines.push(`<div class="event"><h3>${idx + 1}. ${esc(anyEv.type)}${at}</h3>`) 
     switch (ev.type) {
-      case 'Message':
+      case 'Message': {
+        const content = typeof ev.content === 'string'
+          ? ev.content
+          : ev.content.map((p) => ('text' in p ? String((p as any).text) : '')).join('\n')
         lines.push(`<div><span class="badge">${esc(ev.role)}</span>${ev.model ? `<span class="badge">${esc(ev.model)}</span>` : ''}</div>`)
-        lines.push(pre(ev.content))
+        lines.push(pre(content))
         break
+      }
       case 'Reasoning':
         lines.push(pre(ev.content))
         break

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -7,7 +7,10 @@ export function normalize(q: string) {
 export function eventText(ev: ResponseItem): string {
   switch (ev.type) {
     case 'Message':
-      return [ev.role, ev.model || '', ev.content || ''].join('\n')
+      const msg = typeof ev.content === 'string'
+        ? ev.content
+        : ev.content.map((p) => ('text' in p ? String((p as any).text) : '')).join('\n')
+      return [ev.role, ev.model || '', msg].join('\n')
     case 'Reasoning':
       return ev.content || ''
     case 'LocalShellCall':


### PR DESCRIPTION
## Summary
- allow message events to contain structured message parts
- preserve message part arrays when parsing and render them as text
- add tests for array-based message content

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a24920388328b253cd759c91b736