### PR TITLE
Parse shell function calls into LocalShellCall events

### DIFF
--- a/src/parser/__tests__/validators.test.ts
+++ b/src/parser/__tests__/validators.test.ts
@@ -27,4 +27,24 @@ describe('validators', () => {
     expect(bad.success).toBe(false)
     if (!bad.success) expect(bad.reason).toBe('invalid_schema')
   })
+
+  it('converts shell function call to LocalShellCall and parses output', () => {
+    const line = JSON.stringify({
+      type: 'FunctionCall',
+      name: 'shell',
+      args: JSON.stringify({ command: 'echo 1', cwd: '/tmp' }),
+      result: JSON.stringify({ stdout: '1', stderr: '', exitCode: 0, durationMs: 5 }),
+    })
+    const res = parseResponseItemLine(line)
+    expect(res.success).toBe(true)
+    if (res.success) {
+      expect(res.data.type).toBe('LocalShellCall')
+      expect(res.data.command).toBe('echo 1')
+      expect(res.data.cwd).toBe('/tmp')
+      expect(res.data.stdout).toBe('1')
+      expect(res.data.stderr).toBe('')
+      expect(res.data.exitCode).toBe(0)
+      expect(res.data.durationMs).toBe(5)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- handle `function_call` entries named `shell` by converting them into `LocalShellCall` with parsed command, cwd, and output details
- test shell call conversion and result parsing in validators

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5a24abc548328a4c948f68d436066