### PR TITLE
feat: add chat mode timeline rendering

### DIFF
--- a/src/components/ChatPair.tsx
+++ b/src/components/ChatPair.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import type { ResponseItem } from '../types'
+import { Badge } from './ui/badge'
+
+type MessageItem = Extract<ResponseItem, { type: 'Message' }>
+
+interface ChatPairProps {
+  user: MessageItem
+  assistant?: MessageItem
+}
+
+export default function ChatPair({ user, assistant }: ChatPairProps) {
+  return (
+    <div data-testid="chat-pair" className="grid grid-cols-2 gap-4">
+      <div className="justify-self-start space-y-1">
+        <div className="text-xs text-gray-500 flex items-center gap-2">
+          <Badge variant="secondary">user</Badge>
+        </div>
+        <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2">
+          {user.content}
+        </pre>
+      </div>
+      {assistant && (
+        <div className="justify-self-end space-y-1">
+          <div className="text-xs text-gray-500 flex items-center gap-2 justify-end">
+            <Badge variant="secondary">assistant</Badge>
+          </div>
+          <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2 text-right">
+            {assistant.content}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import type { ResponseItem } from '../types'
+import TimelineView from './TimelineView'
+import EventCard from './EventCard'
+import ChatPair from './ChatPair'
+import ErrorBoundary from './ErrorBoundary'
+import { usePreferences } from '../state/preferences'
+
+interface ItemWrapper {
+  ev: ResponseItem
+  key: string
+  absIndex: number
+}
+
+interface TimelineProps {
+  items: readonly ItemWrapper[]
+  height?: number
+  estimateItemHeight?: number
+  scrollToIndex?: number | null
+  highlight?: string
+  onRevealFile?: (path: string) => void
+  onOpenDiff?: (opts: { path: string; diff?: string }) => void
+}
+
+type DisplayItem =
+  | { kind: 'single'; item: ItemWrapper }
+  | { kind: 'pair'; user: ItemWrapper; assistant: ItemWrapper }
+
+export default function Timeline({
+  items,
+  height = 500,
+  estimateItemHeight = 120,
+  scrollToIndex,
+  highlight,
+  onRevealFile,
+  onOpenDiff,
+}: TimelineProps) {
+  const chatMode = usePreferences((s) => s.chatMode)
+
+  const grouped = React.useMemo<DisplayItem[]>(() => {
+    if (!chatMode) return items.map((it) => ({ kind: 'single', item: it }))
+    const res: DisplayItem[] = []
+    for (let i = 0; i < items.length; i++) {
+      const cur = items[i]!
+      const ev = cur.ev as any
+      if (ev.type === 'Message' && ev.role === 'user') {
+        const next = items[i + 1]
+        if (next) {
+          const nextEv = next.ev as any
+          if (nextEv.type === 'Message' && nextEv.role === 'assistant') {
+            res.push({ kind: 'pair', user: cur, assistant: next })
+            i++
+            continue
+          }
+        }
+      }
+      res.push({ kind: 'single', item: cur })
+    }
+    return res
+  }, [items, chatMode])
+
+  return (
+    <TimelineView
+      items={grouped}
+      height={height}
+      estimateItemHeight={estimateItemHeight}
+      keyForIndex={(it) =>
+        it.kind === 'pair' ? `${it.user.key}-${it.assistant.key}` : it.item.key
+      }
+      scrollToIndex={scrollToIndex}
+      renderItem={(it) => {
+        if (it.kind === 'pair') {
+          return (
+              <div className="mb-2">
+                <ChatPair user={it.user.ev as any} assistant={it.assistant.ev as any} />
+              </div>
+            )
+        }
+        return (
+          <div className="mb-2">
+            <ErrorBoundary name="EventCard">
+              <EventCard
+                item={it.item.ev}
+                index={it.item.absIndex}
+                bookmarkKey={it.item.key}
+                onRevealFile={onRevealFile}
+                highlight={highlight}
+                onOpenDiff={onOpenDiff}
+              />
+            </ErrorBoundary>
+          </div>
+        )
+      }}
+    />
+  )
+}
+

--- a/src/components/__tests__/chatPair.test.tsx
+++ b/src/components/__tests__/chatPair.test.tsx
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import ChatPair from '../ChatPair'
+import type { ResponseItem } from '../../types'
+
+describe('ChatPair', () => {
+  it('renders user and assistant messages', () => {
+    const user = { type: 'Message', role: 'user', content: 'hi' } as any
+    const assistant = { type: 'Message', role: 'assistant', content: 'hello' } as any
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    root.render(<ChatPair user={user} assistant={assistant} />)
+    expect(container.textContent).toContain('hi')
+    expect(container.textContent).toContain('hello')
+    root.unmount()
+    document.body.removeChild(container)
+  })
+})
+

--- a/src/components/__tests__/timeline.test.tsx
+++ b/src/components/__tests__/timeline.test.tsx
@@ -1,0 +1,32 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import Timeline from '../Timeline'
+import { BookmarksProvider } from '../../state/bookmarks'
+import { usePreferences } from '../../state/preferences'
+import type { ResponseItem } from '../../types'
+
+describe('Timeline chat mode', () => {
+  it('groups user and assistant messages into ChatPair', async () => {
+    const events = [
+      { ev: { type: 'Message', role: 'user', content: 'hi' } as ResponseItem, key: 'u1', absIndex: 0 },
+      { ev: { type: 'Message', role: 'assistant', content: 'hello' } as ResponseItem, key: 'a1', absIndex: 1 },
+    ] as const
+    usePreferences.getState().setChatMode(true)
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    root.render(
+      <BookmarksProvider>
+        <Timeline items={events} />
+      </BookmarksProvider>
+    )
+    await Promise.resolve()
+    expect(container.querySelectorAll('[data-testid="chat-pair"]').length).toBe(1)
+    root.unmount()
+    document.body.removeChild(container)
+    usePreferences.getState().setChatMode(false)
+  })
+})
+

--- a/src/state/__tests__/preferences.test.ts
+++ b/src/state/__tests__/preferences.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { usePreferences } from '../preferences'
+
+describe('preferences store', () => {
+  it('toggles chat mode', () => {
+    expect(usePreferences.getState().chatMode).toBe(false)
+    usePreferences.getState().setChatMode(true)
+    expect(usePreferences.getState().chatMode).toBe(true)
+    usePreferences.getState().setChatMode(false)
+  })
+})
+

--- a/src/state/preferences.ts
+++ b/src/state/preferences.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface PreferencesState {
+  chatMode: boolean
+  setChatMode: (v: boolean) => void
+}
+
+export const usePreferences = create<PreferencesState>()(
+  persist(
+    (set) => ({
+      chatMode: false,
+      setChatMode: (chatMode) => set({ chatMode })
+    }),
+    { name: 'csv:preferences' }
+  )
+)
+


### PR DESCRIPTION
## Summary
- add preferences store for chat mode
- render ChatPair and group events in Timeline when chat mode is enabled
- switch App to use new Timeline component

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5a75ed9bc8328bcc9388e536b86c4