### PR TITLE
feat: support structured message content

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -41,6 +41,7 @@ function Highlight({ text, query }: { text: string; query?: string }) {
 }
 
 function MessageEventView({ item, highlight }: { item: Extract<ResponseItem, { type: 'Message' }> ; highlight?: string }) {
+  const text = Array.isArray(item.content) ? item.content.map((p) => p.text).join('\n') : (item.content as string)
   return (
     <div className="space-y-2">
       <div className="text-xs text-gray-500 flex flex-wrap gap-2 items-center">
@@ -48,7 +49,7 @@ function MessageEventView({ item, highlight }: { item: Extract<ResponseItem, { t
         {item.model && <span className="text-gray-400">{item.model}</span>}
       </div>
       <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2 max-h-64 overflow-auto">
-        <Highlight text={item.content} query={highlight} />
+        <Highlight text={text} query={highlight} />
       </pre>
     </div>
   )

--- a/src/parser/__tests__/foreignWrappers.test.ts
+++ b/src/parser/__tests__/foreignWrappers.test.ts
@@ -72,7 +72,9 @@ describe('foreign wrappers and blanks', () => {
     if (r.success) {
       expect((r.data as any).type).toBe('Message')
       expect((r.data as any).role).toBe('user')
-      expect((r.data as any).content).toContain('hello world')
+      expect((r.data as any).content).toEqual([
+        { type: 'text', text: 'hello world' },
+      ])
     }
   })
 

--- a/src/parser/__tests__/validators.test.ts
+++ b/src/parser/__tests__/validators.test.ts
@@ -3,6 +3,14 @@ import { parseSessionMetaLine, parseResponseItemLine } from '../../parser/valida
 
 const metaOk = JSON.stringify({ id: 's1', timestamp: '2025-01-01T00:00:00Z', version: 1 })
 const msgOk = JSON.stringify({ type: 'Message', role: 'user', content: 'hi' })
+const msgArrOk = JSON.stringify({
+  type: 'Message',
+  role: 'user',
+  content: [
+    { type: 'text', text: 'hello' },
+    { type: 'text', text: 'world' },
+  ],
+})
 
 describe('validators', () => {
   it('parses valid meta', () => {
@@ -26,6 +34,25 @@ describe('validators', () => {
     const bad = parseResponseItemLine(JSON.stringify({ type: 'Message', role: 'user' }))
     expect(bad.success).toBe(false)
     if (!bad.success) expect(bad.reason).toBe('invalid_schema')
+  })
+
+  it('parses message content as string or array', () => {
+    const strRes = parseResponseItemLine(msgOk)
+    expect(strRes.success).toBe(true)
+    if (strRes.success) {
+      expect(strRes.data.type).toBe('Message')
+      expect(strRes.data.content).toBe('hi')
+    }
+
+    const arrRes = parseResponseItemLine(msgArrOk)
+    expect(arrRes.success).toBe(true)
+    if (arrRes.success) {
+      expect(arrRes.data.type).toBe('Message')
+      expect(arrRes.data.content).toEqual([
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' },
+      ])
+    }
   })
 
   // Generic function calls remain FunctionCall events

--- a/src/parser/schemas.ts
+++ b/src/parser/schemas.ts
@@ -25,10 +25,15 @@ const BaseEvent = z.object({
   index: z.number().int().optional(),
 }).passthrough()
 
+const MessagePartSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+}).passthrough()
+
 const MessageEventSchema = BaseEvent.extend({
   type: z.literal('Message'),
   role: z.string(),
-  content: z.string(),
+  content: z.union([z.string(), z.array(MessagePartSchema)]),
   model: z.string().optional(),
 })
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -8,12 +8,21 @@ export interface BaseEvent {
 }
 
 /**
+ * Structured segments that make up a message. Currently only plain text parts
+ * are supported, but the shape is future proof for richer content.
+ */
+export interface MessagePart {
+  readonly type: 'text'
+  readonly text: string
+}
+
+/**
  * Message emitted by user/assistant/system.
  */
 export interface MessageEvent extends BaseEvent {
   readonly type: 'Message'
   readonly role: 'user' | 'assistant' | 'system' | string
-  readonly content: string
+  readonly content: string | ReadonlyArray<MessagePart>
   readonly model?: string
 }
 

--- a/src/utils/exporters.ts
+++ b/src/utils/exporters.ts
@@ -1,7 +1,12 @@
 import type { ParsedSession } from '../types/session'
 import type { ResponseItem } from '../types'
+import type { MessagePart } from '../types/events'
 import { downloadText } from './download'
 import { toCSV } from '../export/csv'
+
+function asText(content: string | ReadonlyArray<MessagePart>): string {
+  return Array.isArray(content) ? content.map((p) => p.text).join('\n') : (content as string)
+}
 
 export function toJson(meta: ParsedSession['meta'] | undefined, events: readonly ResponseItem[]) {
   return JSON.stringify({ meta, events }, null, 2)
@@ -33,7 +38,7 @@ export function toMarkdown(meta: ParsedSession['meta'] | undefined, events: read
     lines.push('', `### ${idx + 1}. ${anyEv.type}${anyEv.at ? ` — ${anyEv.at}` : ''}`)
     switch (ev.type) {
       case 'Message':
-        lines.push(`- role: ${ev.role}`, '```', ev.content, '```')
+        lines.push(`- role: ${ev.role}`, '```', asText(ev.content), '```')
         break
       case 'Reasoning':
         lines.push('```', ev.content, '```')
@@ -137,7 +142,7 @@ export function toHtml(meta: ParsedSession['meta'] | undefined, events: readonly
     switch (ev.type) {
       case 'Message':
         lines.push(`<div><span class="badge">${esc(ev.role)}</span>${ev.model ? `<span class="badge">${esc(ev.model)}</span>` : ''}</div>`)
-        lines.push(pre(ev.content))
+        lines.push(pre(asText(ev.content)))
         break
       case 'Reasoning':
         lines.push(pre(ev.content))


### PR DESCRIPTION
## Summary
- allow message events to carry structured segments
- preserve message part arrays during parsing and exports

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5a80383a483289d7e73845cd3b41a