### PR TITLE
feat: add file change analyzer

### DIFF
--- a/src/utils/__tests__/fileChanges.test.ts
+++ b/src/utils/__tests__/fileChanges.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { analyzeFileChanges } from '../fileChanges'
+import type { ResponseItem } from '../../types'
+
+describe('analyzeFileChanges', () => {
+  it('maps files and call ids from apply_patch events', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: foo.txt',
+      '+hello',
+      '*** Update File: bar.txt',
+      '@@ -1,1 +1,1 @@',
+      '-old',
+      '+new',
+      '*** End Patch',
+    ].join('\n')
+
+    const events: ResponseItem[] = [
+      {
+        type: 'FunctionCall',
+        name: 'shell',
+        args: JSON.stringify({ command: ['apply_patch', patch] }),
+        result: { output: 'Success. Updated the following files:\nA foo.txt\nM bar.txt\n' },
+        call_id: 'c1',
+        at: '2025-01-01T00:00:00Z',
+        index: 1,
+      } as any,
+    ]
+
+    const res = analyzeFileChanges(events)
+    expect(res.get('foo.txt')?.length).toBe(1)
+    expect(res.get('bar.txt')?.[0]?.diff).toContain('@@')
+    expect(res.callIdToFiles.get('c1')).toEqual(['foo.txt', 'bar.txt'])
+  })
+})
+

--- a/src/utils/fileChanges.ts
+++ b/src/utils/fileChanges.ts
@@ -1,0 +1,66 @@
+import type { ResponseItem, FileChangeEvent } from '../types'
+import { isApplyPatchFunction } from './functionFilters'
+import { extractApplyPatchText, parseApplyPatch } from '../parsers/applyPatch'
+
+export interface FileChangeIndex extends Map<string, FileChangeEvent[]> {
+  callIdToFiles: Map<string, string[]>
+}
+
+function outputText(res: unknown): string {
+  if (typeof res === 'string') return res
+  if (res && typeof res === 'object') {
+    const out = (res as any).output
+    if (typeof out === 'string') return out
+    return JSON.stringify(res)
+  }
+  return ''
+}
+
+function parseOutputForPaths(text: string): string[] {
+  const paths: string[] = []
+  for (const line of text.split('\n')) {
+    const m = line.trim().match(/^[AMD]\s+(.+)$/)
+    if (m) paths.push(m[1]!.trim())
+  }
+  return paths
+}
+
+export function analyzeFileChanges(events: readonly ResponseItem[]): FileChangeIndex {
+  const fileToChanges = new Map<string, FileChangeEvent[]>() as FileChangeIndex
+  const callToFiles = new Map<string, string[]>()
+
+  for (const ev of events) {
+    if (!isApplyPatchFunction(ev)) continue
+    const callId = String((ev as any).call_id || ev.id || '')
+    if (!callId) continue
+
+    const patch = extractApplyPatchText((ev as any).args)
+    const ops = patch ? parseApplyPatch(patch) : []
+
+    const text = outputText((ev as any).result)
+    const paths = parseOutputForPaths(text)
+    if (paths.length === 0 && ops.length > 0) {
+      for (const op of ops) paths.push(op.newPath ?? op.path)
+    }
+    callToFiles.set(callId, Array.from(new Set(paths)))
+
+    for (const path of paths) {
+      const op = ops.find((o) => o.path === path || o.newPath === path)
+      const change: FileChangeEvent = {
+        type: 'FileChange',
+        path,
+        diff: op?.unifiedDiff,
+        id: callId,
+        at: (ev as any).at,
+        index: (ev as any).index,
+      }
+      const arr = fileToChanges.get(path)
+      if (arr) arr.push(change)
+      else fileToChanges.set(path, [change])
+    }
+  }
+
+  fileToChanges.callIdToFiles = callToFiles
+  return fileToChanges
+}
+


### PR DESCRIPTION
## Summary
- add analyzeFileChanges utility to map shell apply_patch events to file paths
- provide callId-to-file lookup and per-file diff events
- test mapping across added and updated files

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a761173483289ea53ada8b29814e