### PR TITLE
feat: add analyze file changes utility

### DIFF
--- a/src/utils/__tests__/fileChanges.test.ts
+++ b/src/utils/__tests__/fileChanges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getFileHistory } from '../fileChanges'
+import { getFileHistory, analyzeFileChanges } from '../fileChanges'
 import type { ResponseItem } from '../../types/events'
 
 describe('getFileHistory', () => {
@@ -14,6 +14,35 @@ describe('getFileHistory', () => {
     expect(hist).toHaveLength(2)
     expect(hist[0]!.diff).toBe('diff1')
     expect(hist[1]!.diff).toBe('diff3')
+  })
+})
+
+describe('analyzeFileChanges', () => {
+  it('maps apply_patch calls to file changes', () => {
+    const patch = `*** Begin Patch\n*** Add File: src/a.ts\n@@\n+hi\n*** End Patch\n`
+    const events: ResponseItem[] = [
+      {
+        type: 'FunctionCall',
+        name: 'shell',
+        args: JSON.stringify({ command: ['apply_patch', patch] }),
+        call_id: 'c1',
+        at: '2024-01-01T00:00:00Z',
+        index: 1,
+      },
+      {
+        type: 'LocalShellCall',
+        command: 'apply_patch',
+        stdout: 'Success. Updated the following files:\nA src/a.ts\n',
+        call_id: 'c1',
+        at: '2024-01-01T00:00:01Z',
+        index: 2,
+      },
+    ] as any
+    const res = analyzeFileChanges(events)
+    const hist = res.fileMap.get('src/a.ts')
+    expect(hist).toBeDefined()
+    expect(hist![0]!.diff).toContain('+++ src/a.ts')
+    expect(res.callToFiles.get('c1')).toEqual(['src/a.ts'])
   })
 })
 

--- a/src/utils/fileChanges.ts
+++ b/src/utils/fileChanges.ts
@@ -1,5 +1,66 @@
 import type { ResponseItem, FileChangeEvent } from '../types/events'
 import { normalizePath } from './fileTree'
+import { extractApplyPatchText, parseApplyPatch } from '../parsers/applyPatch'
+import { isApplyPatchFunction } from './functionFilters'
+
+export interface AnalyzeFileChangesResult {
+  readonly fileMap: Map<string, (FileChangeEvent & { callId?: string })[]>
+  readonly callToFiles: Map<string, string[]>
+}
+
+/**
+ * Scan events for shell apply_patch calls and map affected files.
+ */
+export function analyzeFileChanges(events: readonly ResponseItem[]): AnalyzeFileChangesResult {
+  const outputs = new Map<string, string>()
+  for (const ev of events) {
+    const cid = (ev as any).call_id
+    if (ev.type === 'LocalShellCall' && cid && typeof (ev as any).stdout === 'string') {
+      outputs.set(cid, (ev as any).stdout)
+    }
+  }
+
+  const fileMap = new Map<string, (FileChangeEvent & { callId?: string })[]>()
+  const callToFiles = new Map<string, string[]>()
+
+  for (const ev of events) {
+    if (!isApplyPatchFunction(ev)) continue
+    const callId = (ev as any).call_id as string | undefined
+    const patchText = extractApplyPatchText((ev as any).args)
+    if (!patchText) continue
+    const ops = parseApplyPatch(patchText)
+    const files = new Set<string>(parseOutputFiles(callId ? outputs.get(callId) : undefined))
+
+    for (const op of ops) {
+      const path = normalizePath(op.newPath ?? op.path)
+      files.add(path)
+      const item: FileChangeEvent & { callId?: string } = {
+        type: 'FileChange',
+        path,
+        diff: op.unifiedDiff,
+        at: (ev as any).at,
+        index: (ev as any).index,
+        ...(callId ? { callId } : {}),
+      }
+      const arr = fileMap.get(path)
+      if (arr) arr.push(item)
+      else fileMap.set(path, [item])
+    }
+    if (callId) callToFiles.set(callId, [...files])
+  }
+
+  return { fileMap, callToFiles }
+}
+
+function parseOutputFiles(stdout?: string): string[] {
+  if (!stdout) return []
+  const paths: string[] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    const m = /^[A-Z]\s+(.+)$/.exec(line.trim())
+    if (m) paths.push(normalizePath(m[1]!.trim()))
+  }
+  return paths
+}
 
 export interface FileHistoryEntry {
   readonly path: string


### PR DESCRIPTION
## Summary
- add `analyzeFileChanges` to map shell apply_patch calls to file changes
- include unit test for analyzeFileChanges

## Testing
- `npm run typecheck` *(fails: ChatPair.tsx type errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5aaf01e948328b7e6d020a66d1b38