### PR TITLE
Wrap CommandsView in CollapsibleCard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -996,13 +996,15 @@ function AppInner() {
       )}
 
       {loader.state.events && loader.state.events.length > 0 && (
-        <CommandsView
-          key={`cmds-${sessionKey}`}
-          events={loader.state.events as any}
-          onJumpToIndex={(idx) => {
-            setScrollToIndex(idx)
-          }}
-        />
+        <CollapsibleCard title="Commands" defaultOpen>
+          <CommandsView
+            key={`cmds-${sessionKey}`}
+            events={loader.state.events as any}
+            onJumpToIndex={(idx) => {
+              setScrollToIndex(idx)
+            }}
+          />
+        </CollapsibleCard>
       )}
 
       {loader.state.events && loader.state.events.length > 0 && (


### PR DESCRIPTION
## Summary
- display command list inside a collapsible card titled "Commands"
- keep `onJumpToIndex` prop forwarding to CommandsView

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5aec3b998832885e2192e22d8c695