### PR TITLE
Render apply_patch diffs for shell events

### DIFF
--- a/src/components/__tests__/localShellCallView.test.ts
+++ b/src/components/__tests__/localShellCallView.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import EventCard from '../EventCard'
+import { BookmarksProvider } from '../../state/bookmarks'
+
+describe('LocalShellCallView (apply_patch)', () => {
+  it('renders diff from apply_patch command', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: a.txt',
+      '@@',
+      '-foo',
+      '+bar',
+      '*** End Patch',
+      '',
+    ].join('\n')
+    const command = `apply_patch <<'PATCH'\n${patch}\nPATCH`
+    const item = { type: 'LocalShellCall', command } as any
+    const html = renderToString(
+      React.createElement(BookmarksProvider, null, React.createElement(EventCard, { item }))
+    )
+    expect(html).toContain('a.txt')
+    expect(html).toContain('apply_patch')
+  })
+})

--- a/src/parsers/__tests__/applyPatch.test.ts
+++ b/src/parsers/__tests__/applyPatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractApplyPatchText, parseApplyPatch } from '../applyPatch'
+import { extractApplyPatchText, parseApplyPatch, extractApplyPatchFromCommand } from '../applyPatch'
 import * as fs from 'node:fs'
 
 describe('applyPatch parser', () => {
@@ -13,6 +13,15 @@ describe('applyPatch parser', () => {
     if (!patchText) return
     expect(patchText.startsWith('*** Begin Patch')).toBe(true)
     expect(patchText.includes('*** Update File: src/export/columns.ts')).toBe(true)
+  })
+
+  it('extracts patch text from shell command here-doc', () => {
+    const raw = fs.readFileSync('docs/example-patch.json', 'utf8')
+    const event = JSON.parse(raw)
+    const patchText = extractApplyPatchText(event.args)!
+    const cmd = `apply_patch <<'PATCH'\n${patchText}\nPATCH`
+    const extracted = extractApplyPatchFromCommand(cmd)
+    expect(extracted?.trim()).toBe(patchText.trim())
   })
 
   it('parses Update File ops into minimal unified diffs', () => {

--- a/src/parsers/applyPatch.ts
+++ b/src/parsers/applyPatch.ts
@@ -29,6 +29,24 @@ export function extractApplyPatchText(args: unknown): string | null {
   }
 }
 
+/** Try to extract the raw patch text from a shell command here-doc. */
+export function extractApplyPatchFromCommand(command: string): string | null {
+  try {
+    if (!command) return null
+    const m = /apply_patch\s+<<['"]?([A-Za-z0-9_-]+)['"]?\n([\s\S]*)/.exec(command)
+    if (!m) return null
+    const marker = m[1]
+    const rest = m[2] ?? ''
+    const endMarker = `\n${marker}`
+    const idx = rest.indexOf(endMarker)
+    if (idx === -1) return null
+    const patch = rest.slice(0, idx)
+    return patch || null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Parse an apply_patch envelope (*** Begin Patch ... *** End Patch) into file-level ops.
  * Produces minimal unified diffs so existing utilities can render both sides.


### PR DESCRIPTION
## Summary
- extract apply_patch payloads from LocalShellCall commands
- render parsed diffs inside LocalShellCall event cards
- test apply_patch parsing and rendering for shell commands

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5affc1a008328a8996d0f07ead57c