### PR TITLE
Merge call outputs by ID to prevent duplicate keys

### DIFF
--- a/src/parser/__tests__/streaming.test.ts
+++ b/src/parser/__tests__/streaming.test.ts
@@ -51,4 +51,25 @@ describe('streaming parser', () => {
     expect(evt.args).toEqual({ x: 1 })
     expect(evt.result).toBe('done')
   })
+
+  it('merges LocalShellCall output into prior event by call_id', async () => {
+    const call = JSON.stringify({
+      type: 'function_call',
+      name: 'shell',
+      call_id: 'c1',
+      arguments: '{"command":"echo 1"}',
+    })
+    const out = JSON.stringify({
+      type: 'function_call_output',
+      call_id: 'c1',
+      output: '{"stdout":"1","stderr":"","exit_code":0}',
+    })
+    const blob = makeBlob([meta, call, out])
+    const res = await parseSessionToArrays(blob)
+    expect(res.events.length).toBe(1)
+    const evt = res.events[0] as any
+    expect(evt.type).toBe('LocalShellCall')
+    expect(evt.stdout).toBe('1')
+    expect(evt.exitCode).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary
- merge function and shell call outputs into prior events when they share the same call_id
- add regression test for LocalShellCall output merging

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b6b63e208328b909460b8f22fd2c