### PR TITLE
Handle apply_patch text in result output

### DIFF
--- a/src/components/ApplyPatchView.tsx
+++ b/src/components/ApplyPatchView.tsx
@@ -13,7 +13,10 @@ export interface ApplyPatchViewProps {
 }
 
 export default function ApplyPatchView({ item, pairedResultMeta }: ApplyPatchViewProps) {
-  const patchText = React.useMemo(() => extractApplyPatchText(item.args), [item.args])
+  const patchText = React.useMemo(
+    () => extractApplyPatchText(item.args) ?? extractApplyPatchText((item as any).result),
+    [item.args, (item as any).result]
+  )
 
   if (!patchText) {
     return (

--- a/src/components/__tests__/applyPatchView.test.ts
+++ b/src/components/__tests__/applyPatchView.test.ts
@@ -11,6 +11,15 @@ function makeEventWithPatch(patch: string) {
   } as any
 }
 
+function makeEventWithPatchInResult(patch: string) {
+  return {
+    type: 'FunctionCall',
+    name: 'shell',
+    args: '{}',
+    result: { output: patch },
+  } as any
+}
+
 describe('ApplyPatchView (SSR snapshot)', () => {
   it('renders header and raw toggle for a simple update patch', () => {
     const patch = [
@@ -29,5 +38,20 @@ describe('ApplyPatchView (SSR snapshot)', () => {
     expect(html).toContain('apply_patch')
     // should include file name button or label
     expect(html).toContain('a.txt')
+  })
+
+  it('renders diff when patch text is in result.output', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: b.txt',
+      '@@',
+      '-foo',
+      '+baz',
+      '*** End Patch',
+      '',
+    ].join('\n')
+    const item = makeEventWithPatchInResult(patch)
+    const html = renderToString(React.createElement(ApplyPatchView, { item }))
+    expect(html).toContain('b.txt')
   })
 })

--- a/src/parsers/__tests__/applyPatch.test.ts
+++ b/src/parsers/__tests__/applyPatch.test.ts
@@ -15,6 +15,13 @@ describe('applyPatch parser', () => {
     expect(patchText.includes('*** Update File: src/export/columns.ts')).toBe(true)
   })
 
+  it('extracts patch text from result.output field', () => {
+    const patch = ['*** Begin Patch', '*** Update File: a.txt', '@@', '-foo', '+bar', '*** End Patch', ''].join('\n')
+    const res = { output: patch }
+    const extracted = extractApplyPatchText(res)
+    expect(extracted?.trim()).toBe(patch.trim())
+  })
+
   it('extracts patch text from shell command here-doc', () => {
     const raw = fs.readFileSync('docs/example-patch.json', 'utf8')
     const event = JSON.parse(raw)


### PR DESCRIPTION
## Summary
- detect patch text within result payloads by recursively scanning result objects
- fallback to result data when parsing apply_patch in ApplyPatchView and EventCard
- test extraction and rendering when patch text only appears in result.output

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c1f5879c8328821760924210404d