### PR TITLE
feat(theme): add color scheme picker

### DIFF
--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -40,9 +40,9 @@ export default function DiffView({ path, original, modified, language, height = 
 
   if (isBinary) {
     return (
-      <div className="border rounded">
-        <div className="px-2 py-1 text-xs text-gray-600 border-b bg-gray-50">{path || 'Diff'}</div>
-        <div className="p-3 text-sm text-gray-600">Binary file – cannot display diff</div>
+      <div className="border rounded border-foreground/20 bg-background text-foreground">
+        <div className="px-2 py-1 text-xs text-foreground/70 border-b border-foreground/20 bg-background/80">{path || 'Diff'}</div>
+        <div className="p-3 text-sm text-foreground/70">Binary file – cannot display diff</div>
       </div>
     )
   }
@@ -60,9 +60,9 @@ export default function DiffView({ path, original, modified, language, height = 
       }
     }, [original, modified])
     return (
-      <div className="border rounded">
-        <div className="px-2 py-1 text-xs text-gray-600 border-b bg-gray-50">{path || 'Diff'}</div>
-        <div className="p-3 text-sm text-gray-600">
+      <div className="border rounded border-foreground/20 bg-background text-foreground">
+        <div className="px-2 py-1 text-xs text-foreground/70 border-b border-foreground/20 bg-background/80">{path || 'Diff'}</div>
+        <div className="p-3 text-sm text-foreground/70">
           <p className="mb-2">
             Diff too large to display. Showing first {previewLines} lines.{' '}
             <a href={downloadUrl} download="diff.txt" className="text-blue-600 hover:underline">
@@ -70,10 +70,10 @@ export default function DiffView({ path, original, modified, language, height = 
             </a>
           </p>
           <div className="grid grid-cols-2 gap-2">
-            <pre className="bg-gray-50 p-2 rounded overflow-auto max-h-[420px]" aria-label="Original">
+            <pre className="bg-background/80 p-2 rounded overflow-auto max-h-[420px]" aria-label="Original">
               {safeTruncate(previewOriginal, 20_000)}
             </pre>
-            <pre className="bg-gray-50 p-2 rounded overflow-auto max-h-[420px]" aria-label="Modified">
+            <pre className="bg-background/80 p-2 rounded overflow-auto max-h-[420px]" aria-label="Modified">
               {safeTruncate(previewModified, 20_000)}
             </pre>
           </div>
@@ -95,14 +95,14 @@ export default function DiffView({ path, original, modified, language, height = 
   )
 
   return (
-    <div className="border rounded">
-      <div className="px-2 py-1 text-xs text-gray-600 border-b bg-gray-50/95 backdrop-blur supports-[backdrop-filter]:bg-gray-50/75 sticky top-0 z-10 flex items-center justify-between">
+    <div className="border rounded border-foreground/20 bg-background text-foreground">
+      <div className="px-2 py-1 text-xs text-foreground/70 border-b border-foreground/20 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-10 flex items-center justify-between">
         <span className="truncate" title={path}>{path || 'Diff'}</span>
         <div className="flex items-center gap-2">
           <label className="sr-only">Editor theme</label>
           <select
             aria-label="Editor theme"
-            className="border rounded px-1 py-0.5 bg-white text-gray-700"
+            className="border border-foreground/20 rounded px-1 py-0.5 bg-background text-foreground"
             value={editorThemePref}
             onChange={(e) => setEditorThemePref(e.target.value as any)}
             title="Editor theme"
@@ -111,28 +111,28 @@ export default function DiffView({ path, original, modified, language, height = 
             <option value="light">light</option>
             <option value="dark">dark</option>
           </select>
-          <button className="text-gray-500 hover:text-gray-700" onClick={() => setWrap((w) => !w)} title="Toggle wrap">
+          <button className="text-foreground/70 hover:text-foreground" onClick={() => setWrap((w) => !w)} title="Toggle wrap">
             {wrap ? 'Wrap' : 'No wrap'}
           </button>
           <button
-            className="text-gray-500 hover:text-gray-700"
+            className="text-foreground/70 hover:text-foreground"
             onClick={() => setSideBySide((s) => !s)}
             title="Toggle view"
           >
             {sideBySide ? 'Split' : 'Inline'}
           </button>
-          <span className="text-gray-400">{lang}</span>
+          <span className="text-foreground/50">{lang}</span>
         </div>
       </div>
       <React.Suspense
         fallback={
-          <div className="p-3 text-sm text-gray-600">
+          <div className="p-3 text-sm text-foreground/70">
             <p className="mb-2">Loading Monaco DiffEditor…</p>
             <div className="grid grid-cols-2 gap-2">
-              <pre className="bg-gray-50 p-2 rounded overflow-auto max-h-[420px]" aria-label="Original">
+              <pre className="bg-background/80 p-2 rounded overflow-auto max-h-[420px]" aria-label="Original">
                 {original}
               </pre>
-              <pre className="bg-gray-50 p-2 rounded overflow-auto max-h-[420px]" aria-label="Modified">
+              <pre className="bg-background/80 p-2 rounded overflow-auto max-h-[420px]" aria-label="Modified">
                 {modified}
               </pre>
             </div>

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -83,14 +83,14 @@ export default function FilePreview({ path, events, onOpenDiff, maxChars = 200_0
 
   return (
     <div className="space-y-2">
-      <div className="text-xs text-gray-500 flex items-center justify-between gap-2">
+      <div className="text-xs text-foreground/70 flex items-center justify-between gap-2">
         <div className="truncate" title={path}>{path}</div>
-        <div className="flex items-center gap-2"><span className="text-gray-400">{lang}</span></div>
+        <div className="flex items-center gap-2"><span className="text-foreground/50">{lang}</span></div>
       </div>
-      <pre className="text-xs bg-gray-50 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap" aria-label="File preview">
+      <pre className="text-xs bg-background/80 rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap" aria-label="File preview">
 {display || 'No preview content.'}
       </pre>
-      <div className="text-xs text-gray-500 flex items-center justify-between">
+      <div className="text-xs text-foreground/70 flex items-center justify-between">
         <span>{info}{clipped && ' Large file truncated.'}</span>
         {onOpenDiff && unifiedForOpen && (
           <Button size="sm" variant="outline" onClick={() => onOpenDiff({ path, diff: unifiedForOpen! })}>Open diff</Button>

--- a/src/components/ThemeDrawer.tsx
+++ b/src/components/ThemeDrawer.tsx
@@ -12,8 +12,8 @@ export default function ThemeDrawer() {
       <Dialog open={open} onClose={() => setOpen(false)} className="relative z-50">
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
         <div className="fixed inset-0 flex items-stretch justify-end">
-          <Dialog.Panel className="h-full w-full max-w-md bg-white shadow-xl flex flex-col outline-none">
-            <div className="p-4 border-b flex items-center justify-between">
+          <Dialog.Panel className="h-full w-full max-w-md bg-background text-foreground border-l border-foreground/20 shadow-xl flex flex-col outline-none">
+            <div className="p-4 border-b border-foreground/20 flex items-center justify-between">
               <Dialog.Title className="text-base font-semibold">Appearance</Dialog.Title>
               <Button variant="ghost" size="sm" aria-label="Close" onClick={() => setOpen(false)}>Close</Button>
             </div>

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -33,18 +33,33 @@ function contrastRatio(a: [number, number, number], b: [number, number, number])
 }
 
 export default function ThemePicker() {
-  const { theme, mode, setTheme, setMode, customPrimary, setCustomPrimary } = useTheme()
+  const {
+    theme,
+    mode,
+    setTheme,
+    setMode,
+    customPrimary,
+    setCustomPrimary,
+    customBackground,
+    setCustomBackground,
+  } = useTheme()
   const [hex, setHex] = useState<string>(customPrimary ?? swatches[theme] ?? '#0d9488')
+  const [bgHex, setBgHex] = useState<string>(customBackground ?? '#ffffff')
   const [contrastWarn, setContrastWarn] = useState<string | null>(null)
 
   // Sync local input with store
   useEffect(() => {
     setHex(customPrimary ?? swatches[theme] ?? '#0d9488')
-  }, [customPrimary, theme])
+    setBgHex(customBackground ?? '#ffffff')
+  }, [customPrimary, customBackground, theme])
 
   useEffect(() => {
     setCustomPrimary(hex)
   }, [hex, setCustomPrimary])
+
+  useEffect(() => {
+    setCustomBackground(bgHex)
+  }, [bgHex, setCustomBackground])
 
   const computeContrast = useMemo(() => () => {
     try {
@@ -66,10 +81,10 @@ export default function ThemePicker() {
 
   useEffect(() => {
     setContrastWarn(computeContrast())
-  }, [theme, mode, customPrimary, computeContrast])
+  }, [theme, mode, customPrimary, customBackground, computeContrast])
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-start gap-4">
       <div className="flex items-center gap-3">
         <div className="flex flex-col gap-2">
           <div className="text-sm font-medium">Primary Color</div>
@@ -104,6 +119,32 @@ export default function ThemePicker() {
                   title="Reset to theme defaults"
                 >Reset</button>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <div className="flex flex-col gap-2">
+          <div className="text-sm font-medium">Background</div>
+          <div className="flex items-center gap-3">
+            <div className="w-40">
+              <HexColorPicker color={bgHex} onChange={setBgHex} className="h-28 w-40" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span className="text-xs">Hex</span>
+                <div className="flex items-center gap-1 border rounded px-2 py-1 bg-background text-foreground">
+                  <span className="text-xs">#</span>
+                  <HexColorInput color={bgHex} onChange={setBgHex} prefixed={false} className="text-sm w-24 outline-none bg-transparent" aria-label="Background color hex" />
+                </div>
+              </div>
+              <button
+                type="button"
+                className="ml-1 text-xs underline self-start"
+                onClick={() => setCustomBackground(null)}
+                title="Reset background"
+              >Reset</button>
             </div>
           </div>
         </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -9,7 +9,7 @@ const variants: Record<Variant, string> = {
   // Active chip: filled accent (primary)
   default: 'border-transparent bg-primary text-primary-foreground',
   // Neutral chip: subtle border only
-  secondary: 'border-gray-600 text-gray-200',
+  secondary: 'border-foreground/20 text-foreground',
   destructive: 'border-transparent bg-red-600 text-white',
   outline: 'border-primary text-primary'
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,10 +9,10 @@ const base =
 
 const variants: Record<Variant, string> = {
   default: 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm',
-  secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700',
+  secondary: 'bg-background text-foreground hover:bg-background/80',
   destructive: 'bg-red-600 text-white hover:bg-red-500',
-  outline: 'border border-gray-300 bg-white text-gray-800 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800',
-  ghost: 'bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-900 dark:text-gray-100',
+  outline: 'border border-foreground/20 bg-background text-foreground hover:bg-background/80',
+  ghost: 'bg-transparent hover:bg-background/80 text-foreground',
   link: 'bg-transparent text-primary underline-offset-4 hover:underline'
 }
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { cn } from '../../utils/cn'
 
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('rounded-lg border border-gray-800 bg-gray-900 text-gray-100 shadow-sm', className)} {...props} />
+  return <div className={cn('rounded-lg border border-foreground/20 bg-background text-foreground shadow-sm', className)} {...props} />
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
@@ -10,11 +10,11 @@ export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn('text-base font-semibold leading-none tracking-tight text-gray-100', className)} {...props} />
+  return <h3 className={cn('text-base font-semibold leading-none tracking-tight text-foreground', className)} {...props} />
 }
 
 export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn('text-sm text-gray-400', className)} {...props} />
+  return <p className={cn('text-sm text-foreground/70', className)} {...props} />
 }
 
 export function CardAction({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/state/__tests__/theme.test.ts
+++ b/src/state/__tests__/theme.test.ts
@@ -31,5 +31,13 @@ describe('theme store', () => {
     useTheme.getState().setMode('light')
     expect(root.classList.contains('dark')).toBe(false)
   })
+
+  it('applies custom background and foreground', () => {
+    const root = document.documentElement
+    useTheme.getState().setCustomBackground('#ff0000')
+    expect(root.style.getPropertyValue('--background').trim()).toBe('255 0 0')
+    expect(root.style.getPropertyValue('--foreground').trim()).toBe('255 255 255')
+    useTheme.getState().setCustomBackground(null)
+  })
 })
 

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -12,6 +12,9 @@ interface ThemeState {
   // When set, overrides --primary regardless of `theme`
   customPrimary: string | null
   setCustomPrimary: (hex: string | null) => void
+  // When set, overrides --background and adjusts --foreground
+  customBackground: string | null
+  setCustomBackground: (hex: string | null) => void
 }
 
 const applyTheme = (theme: Theme) => {
@@ -35,6 +38,7 @@ export const useTheme = create<ThemeState>()(
       theme: 'teal',
       mode: 'system',
       customPrimary: null,
+      customBackground: null,
       setTheme: (theme) => {
         applyTheme(theme)
         set({ theme })
@@ -46,6 +50,10 @@ export const useTheme = create<ThemeState>()(
       setCustomPrimary: (hex) => {
         applyCustomPrimary(hex)
         set({ customPrimary: hex, theme: hex ? 'custom' : useTheme.getState().theme })
+      },
+      setCustomBackground: (hex) => {
+        applyCustomBackground(hex)
+        set({ customBackground: hex })
       }
     }),
     {
@@ -55,6 +63,7 @@ export const useTheme = create<ThemeState>()(
           applyTheme(state.theme)
           applyMode(state.mode)
           applyCustomPrimary(state.customPrimary ?? null)
+          applyCustomBackground(state.customBackground ?? null)
         }
       }
     }
@@ -66,6 +75,7 @@ if (typeof document !== 'undefined') {
   applyTheme(useTheme.getState().theme)
   applyMode(useTheme.getState().mode)
   applyCustomPrimary(useTheme.getState().customPrimary)
+  applyCustomBackground(useTheme.getState().customBackground)
 }
 
 // React to system preference changes when in system mode
@@ -93,6 +103,24 @@ function applyCustomPrimary(hex: string | null | undefined) {
     const lum = relativeLuminance(rgb)
     const fg = lum > 0.5 ? '0 0 0' : '255 255 255'
     root.style.setProperty('--primary-foreground', fg)
+  }
+}
+
+function applyCustomBackground(hex: string | null | undefined) {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement as HTMLElement
+  if (!hex) {
+    root.style.removeProperty('--background')
+    root.style.removeProperty('--foreground')
+    return
+  }
+  const rgb = hexToRgb(hex)
+  if (rgb) {
+    const value = `${rgb.r} ${rgb.g} ${rgb.b}`
+    root.style.setProperty('--background', value)
+    const lum = relativeLuminance(rgb)
+    const fg = lum > 0.5 ? '0 0 0' : '255 255 255'
+    root.style.setProperty('--foreground', fg)
   }
 }
 


### PR DESCRIPTION
## Summary
- add customizable background color to theme store and picker
- apply CSS variable-based theming across buttons, cards, diff viewer, and file previews
- ensure theme settings persist and pass contrast checks

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c70c52581483289fa94f3890740e2e