### PR TITLE
Fix theme picker custom color handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^20.19.13",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@testing-library/react": "^14.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "jsdom": "^26.1.0",
     "typescript": "^5.5.4",

--- a/src/components/ThemeDrawer.tsx
+++ b/src/components/ThemeDrawer.tsx
@@ -8,7 +8,17 @@ export default function ThemeDrawer() {
   const [open, setOpen] = React.useState(false)
   return (
     <>
-      <Button variant="outline" size="sm" aria-label="Open appearance settings" onClick={() => setOpen(true)}>Appearance</Button>
+      {!open && (
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Open appearance settings"
+          onClick={() => setOpen(true)}
+          className="fixed bottom-4 right-4 z-40"
+        >
+          Appearance
+        </Button>
+      )}
       <Dialog open={open} onClose={() => setOpen(false)} className="relative z-50">
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
         <div className="fixed inset-0 flex items-stretch justify-end">

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -53,13 +53,9 @@ export default function ThemePicker() {
     setBgHex(customBackground ?? '#ffffff')
   }, [customPrimary, customBackground, theme])
 
-  useEffect(() => {
-    setCustomPrimary(hex)
-  }, [hex, setCustomPrimary])
-
-  useEffect(() => {
-    setCustomBackground(bgHex)
-  }, [bgHex, setCustomBackground])
+  // Apply custom colors only when user edits them to avoid overriding
+  // the stock theme values on initial mount.
+  // Directly update the store from the change handlers below.
 
   const computeContrast = useMemo(() => () => {
     try {
@@ -84,20 +80,30 @@ export default function ThemePicker() {
   }, [theme, mode, customPrimary, customBackground, computeContrast])
 
   return (
-    <div className="flex items-start gap-4">
+    <div className="flex flex-col gap-6">
       <div className="flex items-center gap-3">
         <div className="flex flex-col gap-2">
           <div className="text-sm font-medium">Primary Color</div>
           <div className="flex items-center gap-3">
             <div className="w-40">
-              <HexColorPicker color={hex} onChange={setHex} className="h-28 w-40" />
+              <HexColorPicker
+                color={hex}
+                onChange={(c) => { setHex(c); setCustomPrimary(c) }}
+                className="h-28 w-40"
+              />
             </div>
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
                 <span className="text-xs">Hex</span>
                 <div className="flex items-center gap-1 border rounded px-2 py-1 bg-background text-foreground">
                   <span className="text-xs">#</span>
-                  <HexColorInput color={hex} onChange={setHex} prefixed={false} className="text-sm w-24 outline-none bg-transparent" aria-label="Primary color hex" />
+                  <HexColorInput
+                    color={hex}
+                    onChange={(c) => { setHex(c); setCustomPrimary(c) }}
+                    prefixed={false}
+                    className="text-sm w-24 outline-none bg-transparent"
+                    aria-label="Primary color hex"
+                  />
                 </div>
               </div>
               <div className="flex items-center gap-2">
@@ -108,7 +114,7 @@ export default function ThemePicker() {
                     className="h-6 w-6 rounded border ring-0"
                     style={{ backgroundColor: value }}
                     title={name}
-                    onClick={() => { setTheme(name as any); setCustomPrimary(value) }}
+                    onClick={() => { setTheme(name as any); setCustomPrimary(null) }}
                     aria-label={`Set ${name} theme`}
                   />
                 ))}
@@ -129,14 +135,24 @@ export default function ThemePicker() {
           <div className="text-sm font-medium">Background</div>
           <div className="flex items-center gap-3">
             <div className="w-40">
-              <HexColorPicker color={bgHex} onChange={setBgHex} className="h-28 w-40" />
+              <HexColorPicker
+                color={bgHex}
+                onChange={(c) => { setBgHex(c); setCustomBackground(c) }}
+                className="h-28 w-40"
+              />
             </div>
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
                 <span className="text-xs">Hex</span>
                 <div className="flex items-center gap-1 border rounded px-2 py-1 bg-background text-foreground">
                   <span className="text-xs">#</span>
-                  <HexColorInput color={bgHex} onChange={setBgHex} prefixed={false} className="text-sm w-24 outline-none bg-transparent" aria-label="Background color hex" />
+                  <HexColorInput
+                    color={bgHex}
+                    onChange={(c) => { setBgHex(c); setCustomBackground(c) }}
+                    prefixed={false}
+                    className="text-sm w-24 outline-none bg-transparent"
+                    aria-label="Background color hex"
+                  />
                 </div>
               </div>
               <button

--- a/src/components/__tests__/ThemePicker.test.tsx
+++ b/src/components/__tests__/ThemePicker.test.tsx
@@ -1,0 +1,37 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import ThemePicker from '../ThemePicker'
+import { useTheme } from '../../state/theme'
+
+// Ensure DOM styles don't leak between tests
+beforeEach(() => {
+  document.documentElement.removeAttribute('style')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ThemePicker', () => {
+  it('applies and resets custom primary color', () => {
+    const root = document.documentElement
+    render(<ThemePicker />)
+    const hexInput = screen.getByLabelText('Primary color hex')
+    fireEvent.change(hexInput, { target: { value: 'ff0000' } })
+    expect(root.style.getPropertyValue('--primary').trim()).toBe('255 0 0')
+    fireEvent.click(screen.getByTitle('Reset to theme defaults'))
+    expect(root.style.getPropertyValue('--primary')).toBe('')
+    expect(useTheme.getState().theme).toBe('teal')
+  })
+
+  it('resets custom background color', () => {
+    const root = document.documentElement
+    render(<ThemePicker />)
+    const bgInput = screen.getByLabelText('Background color hex')
+    fireEvent.change(bgInput, { target: { value: '0000ff' } })
+    expect(root.style.getPropertyValue('--background').trim()).toBe('0 0 255')
+    fireEvent.click(screen.getByTitle('Reset background'))
+    expect(root.style.getPropertyValue('--background')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- avoid auto-applying custom colors so default themes render correctly
- update color pickers to write directly to theme store
- add tests for primary/background resets
- stack color pickers vertically and anchor trigger button to keep controls on screen

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7126098f08328b99d5753b3fad71d