### PR TITLE
refactor: streamline theme picker

### DIFF
--- a/src/components/ThemeDrawer.tsx
+++ b/src/components/ThemeDrawer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Dialog } from '@headlessui/react'
 import ThemePicker from './ThemePicker'
 import { Button } from './ui/button'
-import { Badge } from './ui/badge'
 
 export default function ThemeDrawer() {
   const [open, setOpen] = React.useState(false)
@@ -31,16 +30,6 @@ export default function ThemeDrawer() {
               <section>
                 <h3 className="text-sm font-medium mb-2">Theme</h3>
                 <ThemePicker />
-              </section>
-              <section>
-                <h3 className="text-sm font-medium mb-2">Preview</h3>
-                <div className="flex flex-wrap gap-2 items-center">
-                  <Button>Primary Button</Button>
-                  <Button variant="outline">Outline Button</Button>
-                  <Button variant="link">Link Button</Button>
-                  <Badge>Badge</Badge>
-                  <Badge variant="outline">Outline Badge</Badge>
-                </div>
               </section>
             </div>
           </Dialog.Panel>

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -8,6 +8,7 @@ const swatches: Record<string, string> = {
   rose: '#f43f5e',
   indigo: '#4f46e5',
 }
+const themes = Object.keys(swatches) as string[]
 
 function parseRGBTriplet(s: string): [number, number, number] | null {
   const parts = s.trim().split(/\s+/).map((n) => parseFloat(n))
@@ -107,17 +108,20 @@ export default function ThemePicker() {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                {Object.entries(swatches).map(([name, value]) => (
-                  <button
-                    key={name}
-                    type="button"
-                    className="h-6 w-6 rounded border ring-0"
-                    style={{ backgroundColor: value }}
-                    title={name}
-                    onClick={() => { setTheme(name as any); setCustomPrimary(null) }}
-                    aria-label={`Set ${name} theme`}
-                  />
-                ))}
+                <span className="text-xs">Theme</span>
+                <select
+                  className="border rounded px-2 py-1 text-sm bg-background text-foreground"
+                  value={themes.includes(theme) ? theme : 'custom'}
+                  onChange={(e) => { setTheme(e.target.value as any); setCustomPrimary(null) }}
+                  aria-label="Theme select"
+                >
+                  {themes.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                  <option value="custom" disabled>custom</option>
+                </select>
                 <button
                   type="button"
                   className="ml-1 text-xs underline"

--- a/src/components/__tests__/ThemePicker.test.tsx
+++ b/src/components/__tests__/ThemePicker.test.tsx
@@ -34,4 +34,14 @@ describe('ThemePicker', () => {
     fireEvent.click(screen.getByTitle('Reset background'))
     expect(root.style.getPropertyValue('--background')).toBe('')
   })
+
+  it('changes theme via select', () => {
+    const root = document.documentElement
+    render(<ThemePicker />)
+    const select = screen.getByLabelText('Theme select')
+    fireEvent.change(select, { target: { value: 'rose' } })
+    expect(root.getAttribute('data-theme')).toBe('rose')
+    const hexInput = screen.getByLabelText('Primary color hex') as HTMLInputElement
+    expect(hexInput.value).toBe('f43f5e')
+  })
 })


### PR DESCRIPTION
## Summary
- replace theme swatches with a select dropdown that applies themes immediately
- remove unused preview buttons from the appearance drawer
- add regression test for selecting themes via dropdown

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c716eea53883289d8627833c475054