### PR TITLE
Normalize diff provider file reads

### DIFF
--- a/src/scanner/__tests__/diffProvider.test.ts
+++ b/src/scanner/__tests__/diffProvider.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { getWorkspaceDiff } from '../diffProvider'
+
+// Minimal in-memory implementations of FileSystem handles for testing
+class MockFileHandle {
+  constructor(private content: string) {}
+  async getFile() {
+    return { text: async () => this.content }
+  }
+}
+
+class MockDirectoryHandle {
+  constructor(private entries: Record<string, MockDirectoryHandle | MockFileHandle>) {}
+  async getDirectoryHandle(name: string) {
+    const entry = this.entries[name]
+    if (!(entry instanceof MockDirectoryHandle)) throw new Error('directory not found')
+    return entry
+  }
+  async getFileHandle(name: string) {
+    const entry = this.entries[name]
+    if (!(entry instanceof MockFileHandle)) throw new Error('file not found')
+    return entry
+  }
+}
+
+function createRoot() {
+  return new MockDirectoryHandle({
+    dir: new MockDirectoryHandle({
+      'file.txt': new MockFileHandle('content'),
+    }),
+  })
+}
+
+describe('getWorkspaceDiff path normalization', () => {
+  it('loads file for Windows-style path', async () => {
+    const root = createRoot()
+    const res = await getWorkspaceDiff(root as any, 'dir\\file.txt', [])
+    expect(res.modified).toBe('content')
+  })
+
+  it('loads file for path with leading relative segment', async () => {
+    const root = createRoot()
+    const res = await getWorkspaceDiff(root as any, '../dir/file.txt', [])
+    expect(res.modified).toBe('content')
+  })
+})
+

--- a/src/scanner/diffProvider.ts
+++ b/src/scanner/diffProvider.ts
@@ -17,7 +17,7 @@ export async function getWorkspaceDiff(
   const target = normalize(path)
 
   let modified = ''
-  try { modified = await readFileText(root, path) } catch {}
+  try { modified = await readFileText(root, normalize(path)) } catch {}
 
   // Try to find a recent FileChange with a diff for baseline
   let original = ''


### PR DESCRIPTION
## Summary
- normalize path before reading workspace file content
- add tests for Windows and relative paths in diff provider

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd38cf00832880f9d9886fa33884