### PR TITLE
Refactor diff provider flow and add tests

### DIFF
--- a/src/scanner/__tests__/diffProvider.test.ts
+++ b/src/scanner/__tests__/diffProvider.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../utils/fs-io', () => ({
+  readFileText: vi.fn(),
+}))
+
+import { getWorkspaceDiff } from '../diffProvider'
+import { readFileText } from '../../utils/fs-io'
+import * as applyPatchModule from '../../parsers/applyPatch'
+
+const mockReadFileText = vi.mocked(readFileText)
+
+describe('getWorkspaceDiff', () => {
+  it('uses FileChange diff when available', async () => {
+    mockReadFileText.mockResolvedValue('current')
+    const diff = [
+      '--- a/a.txt',
+      '+++ b/a.txt',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+    ].join('\n')
+    const events = [{ type: 'FileChange', path: 'a.txt', diff }]
+    const res = await getWorkspaceDiff({} as any, 'a.txt', events)
+    expect(res.original).toBe('old')
+    expect(res.modified).toBe('current')
+  })
+
+  it('falls back to apply_patch payloads and stops after first match', async () => {
+    mockReadFileText.mockReset()
+    mockReadFileText.mockRejectedValue(new DOMException('nf'))
+    const spy = vi.spyOn(applyPatchModule, 'parseApplyPatch')
+    const makeEvent = (path: string, old: string, mod: string) => ({
+      type: 'FunctionCall',
+      name: 'shell',
+      args: { command: ['apply_patch', ['*** Begin Patch', `*** Update File: ${path}`, '@@', `-${old}`, `+${mod}`, '*** End Patch'].join('\n')] },
+    })
+    const events = [
+      makeEvent('other.txt', 'x', 'y'),
+      makeEvent('file.txt', 'old', 'new'),
+      makeEvent('later.txt', 'a', 'b'),
+    ]
+    const res = await getWorkspaceDiff({} as any, 'file.txt', events)
+    expect(res).toEqual({ original: 'old', modified: 'new' })
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})
+


### PR DESCRIPTION
## Summary
- refactor `getWorkspaceDiff` to use labeled loops and targeted error handling instead of throw/catch for flow control
- add unit tests covering FileChange and apply_patch paths

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd393f4083288c46e149985e0372