### PR TITLE
Handle renamed file paths in fileChanges util

### DIFF
--- a/src/utils/__tests__/fileChanges.test.ts
+++ b/src/utils/__tests__/fileChanges.test.ts
@@ -45,5 +45,20 @@ describe('analyzeFileChanges', () => {
     expect(res.callToFiles.get('c1')).toEqual(['src/a.ts', 'src/b.ts'])
     expect(res.callToFiles.get('c2')).toEqual(['src/a.ts'])
   })
+
+  it('includes old and new paths for rename outputs', () => {
+    const events: ResponseItem[] = [
+      {
+        type: 'FunctionCall',
+        name: 'shell',
+        args: JSON.stringify({ command: ['apply_patch', '...'] }),
+        result: { output: 'Success. Updated the following files:\nR src/old.ts -> src/new.ts\n' },
+        call_id: 'c1',
+      },
+    ] as any
+
+    const res = analyzeFileChanges(events)
+    expect(res.callToFiles.get('c1')).toEqual(['src/old.ts', 'src/new.ts'])
+  })
 })
 

--- a/src/utils/fileChanges.ts
+++ b/src/utils/fileChanges.ts
@@ -74,7 +74,15 @@ function extractPathsFromResult(res: unknown): string[] {
   if (!txt) return []
   const out: string[] = []
   for (const line of String(txt).split(/\r?\n/)) {
-    const m = /^\s*[AMD]\s+(.+)$/.exec(line)
+    // handle rename/copy lines like "R old.ts -> new.ts" or "C a.ts => b.ts"
+    const rename = /^\s*[RC]\s+(.+?)\s+(?:->|=>)\s+(.+)$/.exec(line)
+    if (rename && rename[1] && rename[2]) {
+      out.push(normalizePath(rename[1]))
+      out.push(normalizePath(rename[2]))
+      continue
+    }
+
+    const m = /^\s*[A-Z]\s+(.+)$/.exec(line)
     if (m && m[1]) out.push(normalizePath(m[1]))
   }
   return out


### PR DESCRIPTION
## Summary
- enhance file change parsing to detect rename/copy outputs and capture both old and new paths
- add tests verifying renamed file mappings

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd39dfdc8328ae7ff1d775f01135