### PR TITLE
Handle invalid file history timestamps

### DIFF
--- a/src/utils/__tests__/fileChanges.test.ts
+++ b/src/utils/__tests__/fileChanges.test.ts
@@ -15,6 +15,26 @@ describe('getFileHistory', () => {
     expect(hist[0]!.diff).toBe('diff1')
     expect(hist[1]!.diff).toBe('diff3')
   })
+
+  it('falls back to index when timestamps are invalid', () => {
+    const events: ResponseItem[] = [
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd0', at: '2024-01-01T00:00:00Z', index: 1 },
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd1', at: 'not-a-date', index: 2 },
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd2', at: '2024-01-01T00:02:00Z', index: 3 },
+    ] as any
+    const hist = getFileHistory(events, 'src/a.ts')
+    expect(hist.map((h) => h.diff)).toEqual(['d0', 'd1', 'd2'])
+  })
+
+  it('falls back to index when timestamps are missing', () => {
+    const events: ResponseItem[] = [
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd0', at: '2024-01-01T00:00:00Z', index: 1 },
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd1', index: 2 },
+      { type: 'FileChange', path: 'src/a.ts', diff: 'd2', index: 3 },
+    ] as any
+    const hist = getFileHistory(events, 'src/a.ts')
+    expect(hist.map((h) => h.diff)).toEqual(['d0', 'd1', 'd2'])
+  })
 })
 
 describe('analyzeFileChanges', () => {

--- a/src/utils/fileChanges.ts
+++ b/src/utils/fileChanges.ts
@@ -24,9 +24,9 @@ export function getFileHistory(events: readonly ResponseItem[], filePath: string
     }
   }
   history.sort((a, b) => {
-    const ta = a.at ? Date.parse(a.at as string) : undefined
-    const tb = b.at ? Date.parse(b.at as string) : undefined
-    if (ta !== undefined && tb !== undefined && ta !== tb) return ta - tb
+    const ta = a.at ? Date.parse(a.at) : Number.NaN
+    const tb = b.at ? Date.parse(b.at) : Number.NaN
+    if (!Number.isNaN(ta) && !Number.isNaN(tb) && ta !== tb) return ta - tb
     const ia = a.index ?? 0
     const ib = b.index ?? 0
     return ia - ib


### PR DESCRIPTION
## Summary
- treat `NaN` results from `Date.parse` as missing timestamps in `getFileHistory`
- fall back to event index ordering when timestamps are malformed or absent
- cover invalid and missing timestamp scenarios with new unit tests

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd3b4b948328be33e8b99e690bd2