### PR TITLE
Refactor diff provider and broaden tests

### DIFF
--- a/src/scanner/__tests__/diffProvider.test.ts
+++ b/src/scanner/__tests__/diffProvider.test.ts
@@ -13,35 +13,70 @@ class MockDirectoryHandle {
   constructor(private entries: Record<string, MockDirectoryHandle | MockFileHandle>) {}
   async getDirectoryHandle(name: string) {
     const entry = this.entries[name]
-    if (!(entry instanceof MockDirectoryHandle)) throw new Error('directory not found')
+    if (!(entry instanceof MockDirectoryHandle)) throw new DOMException('directory not found', 'NotFoundError')
     return entry
   }
   async getFileHandle(name: string) {
     const entry = this.entries[name]
-    if (!(entry instanceof MockFileHandle)) throw new Error('file not found')
+    if (!(entry instanceof MockFileHandle)) throw new DOMException('file not found', 'NotFoundError')
     return entry
   }
 }
 
-function createRoot() {
+function createRoot(fileContent?: string) {
+  const fileEntries: Record<string, MockDirectoryHandle | MockFileHandle> = {}
+  if (fileContent !== undefined) {
+    fileEntries['file.txt'] = new MockFileHandle(fileContent)
+  }
   return new MockDirectoryHandle({
-    dir: new MockDirectoryHandle({
-      'file.txt': new MockFileHandle('content'),
-    }),
+    dir: new MockDirectoryHandle(fileEntries),
   })
 }
 
 describe('getWorkspaceDiff path normalization', () => {
   it('loads file for Windows-style path', async () => {
-    const root = createRoot()
+    const root = createRoot('content')
     const res = await getWorkspaceDiff(root as any, 'dir\\file.txt', [])
     expect(res.modified).toBe('content')
   })
 
   it('loads file for path with leading relative segment', async () => {
-    const root = createRoot()
+    const root = createRoot('content')
     const res = await getWorkspaceDiff(root as any, '../dir/file.txt', [])
     expect(res.modified).toBe('content')
+  })
+})
+
+describe('getWorkspaceDiff event handling', () => {
+  it('uses latest FileChange diff as original', async () => {
+    const root = createRoot('after')
+    const diff = ['--- dir/file.txt', '+++ dir/file.txt', '@@', '-before', '+after'].join('\n')
+    const events = [{ type: 'FileChange', path: 'dir/file.txt', diff }]
+    const res = await getWorkspaceDiff(root as any, 'dir/file.txt', events)
+    expect(res.original).toBe('before')
+    expect(res.modified).toBe('after')
+  })
+
+  it('falls back to apply_patch when file missing', async () => {
+    const root = createRoot(undefined)
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: dir/file.txt',
+      '@@',
+      '-before',
+      '+after',
+      '*** End Patch',
+    ].join('\n')
+    const events = [
+      {
+        type: 'FunctionCall',
+        name: 'shell',
+        args: JSON.stringify({ command: ['apply_patch', patch] }),
+      },
+    ]
+    const res = await getWorkspaceDiff(root as any, 'dir/file.txt', events)
+    expect(res.original).toBe('before')
+    expect(res.modified).toBe('after')
   })
 })
 

--- a/src/scanner/diffProvider.ts
+++ b/src/scanner/diffProvider.ts
@@ -17,44 +17,48 @@ export async function getWorkspaceDiff(
   const target = normalize(path)
 
   let modified = ''
-  try { modified = await readFileText(root, normalize(path)) } catch {}
+  try {
+    modified = await readFileText(root, normalize(path))
+  } catch (e) {
+    if (!(e instanceof DOMException)) throw e
+  }
 
   // Try to find a recent FileChange with a diff for baseline
   let original = ''
-  try {
-    for (let i = events.length - 1; i >= 0; i--) {
-      const ev = events[i] as any
-      if (ev && ev.type === 'FileChange' && normalize(ev.path) === target && ev.diff) {
-        const sides = parseUnifiedDiffToSides(ev.diff)
-        original = sides.original
-        break
-      }
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i] as any
+    if (ev && ev.type === 'FileChange' && normalize(ev.path) === target && ev.diff) {
+      const sides = parseUnifiedDiffToSides(ev.diff)
+      original = sides.original
+      break
     }
-  } catch {}
+  }
 
   // Fallback: inspect recent apply_patch payloads for this path
   if (!original) {
-    try {
-      for (let i = events.length - 1; i >= 0; i--) {
-        const ev = events[i] as any
-        if (!isApplyPatchFunction(ev)) continue
-        const patchText = extractApplyPatchText(ev.args)
-        if (!patchText) continue
-        const ops = parseApplyPatch(patchText)
-        for (const op of ops) {
-          const opOld = normalize(op.path)
-          const opNew = op.newPath ? normalize(op.newPath) : undefined
-          if (opOld === target || opNew === target) {
-            const sides = parseUnifiedDiffToSides(op.unifiedDiff)
-            original = sides.original
-            // If we still don't have modified content (e.g., file no longer present), leave modified as-is
-            if (!modified) modified = sides.modified
-            throw new Error('found')
-          }
+    outer: for (let i = events.length - 1; i >= 0; i--) {
+      const ev = events[i] as any
+      if (!isApplyPatchFunction(ev)) continue
+      const patchText = extractApplyPatchText(ev.args)
+      if (!patchText) continue
+      let ops
+      try {
+        ops = parseApplyPatch(patchText)
+      } catch (e) {
+        if (e instanceof SyntaxError) continue
+        throw e
+      }
+      for (const op of ops) {
+        const opOld = normalize(op.path)
+        const opNew = op.newPath ? normalize(op.newPath) : undefined
+        if (opOld === target || opNew === target) {
+          const sides = parseUnifiedDiffToSides(op.unifiedDiff)
+          original = sides.original
+          // If we still don't have modified content (e.g., file no longer present), leave modified as-is
+          if (!modified) modified = sides.modified
+          break outer
         }
       }
-    } catch (e) {
-      // swallow control exception used to break nested loops
     }
   }
 


### PR DESCRIPTION
## Summary
- Refactor `getWorkspaceDiff` to remove exception-based control flow and better handle parsing errors
- Extend tests to cover FileChange and apply_patch event handling

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c81a7ab8288328a1456ad2520f9c41