### PR TITLE
feat: show cwd tags in session loader

### DIFF
--- a/src/hooks/useAutoDiscovery.ts
+++ b/src/hooks/useAutoDiscovery.ts
@@ -4,6 +4,7 @@ export interface DiscoveredSessionAsset {
   path: string
   url: string
   sortKey?: number
+  tags?: readonly string[]
 }
 
 /**

--- a/src/utils/__tests__/session-tags.test.ts
+++ b/src/utils/__tests__/session-tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { extractCwdTagsFromText, extractCwdTagsFromEvents } from '../session-tags'
+
+describe('session cwd tag extraction', () => {
+  it('collects unique cwd strings from session text', () => {
+    const text = [
+      JSON.stringify({ timestamp: '2024-01-01T00:00:00Z', id: 'sess-1', cwd: '/home/user/project/' }),
+      JSON.stringify({ type: 'LocalShellCall', command: 'ls', cwd: '/home/user/project' }),
+      JSON.stringify({ type: 'FunctionCall', name: 'shell', args: { cwd: '/home/user/other' } }),
+      JSON.stringify({ type: 'Other', data: { nested: { cwd: '/tmp/workspace ' } } }),
+    ].join('\n')
+
+    const tags = extractCwdTagsFromText(text)
+    expect(tags).toEqual(['/home/user/project', '/home/user/other', '/tmp/workspace'])
+  })
+
+  it('limits to the requested maximum number of tags', () => {
+    const meta = JSON.stringify({ timestamp: '2024-01-01T00:00:00Z' })
+    const events = Array.from({ length: 10 }, (_, i) => (
+      JSON.stringify({ type: 'LocalShellCall', command: 'echo', cwd: `/repo/${i}` })
+    ))
+    const text = [meta, ...events].join('\n')
+
+    const tags = extractCwdTagsFromText(text, 4)
+    expect(tags).toHaveLength(4)
+    expect(tags).toEqual(['/repo/0', '/repo/1', '/repo/2', '/repo/3'])
+  })
+
+  it('supports extracting from parsed events directly', () => {
+    const meta = { timestamp: '2024-01-01T00:00:00Z', cwd: '/meta/path' }
+    const events = [
+      { type: 'LocalShellCall', command: 'ls', cwd: '/meta/path' },
+      { type: 'CustomToolCall', toolName: 'demo', output: { cwd: '/tool/output' } },
+    ] as any
+
+    const tags = extractCwdTagsFromEvents(meta as any, events)
+    expect(tags).toEqual(['/meta/path', '/tool/output'])
+  })
+})

--- a/src/utils/session-tags.ts
+++ b/src/utils/session-tags.ts
@@ -1,0 +1,99 @@
+import { parseResponseItemLine, parseSessionMetaLine } from '../parser'
+import type { ResponseItemParsed, SessionMetaParsed } from '../parser'
+
+const MAX_TAGS_DEFAULT = 6
+
+function normalizeTag(input: string): string {
+  let value = input.trim()
+  if (!value) return input.trim()
+  value = value.replace(/\s+/g, ' ')
+  // Collapse redundant trailing slashes
+  value = value.replace(/[\\/]+$/g, '')
+  return value || input.trim()
+}
+
+function collectCwdsFromValue(value: unknown, acc: Set<string>, seen: WeakSet<object>) {
+  if (!value) return
+  if (Array.isArray(value)) {
+    for (const item of value) collectCwdsFromValue(item, acc, seen)
+    return
+  }
+  if (typeof value !== 'object') return
+  if (seen.has(value as object)) return
+  seen.add(value as object)
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof key === 'string' && key.toLowerCase() === 'cwd') {
+      if (typeof nested === 'string') {
+        const normalized = normalizeTag(nested)
+        if (normalized) acc.add(normalized)
+      } else if (Array.isArray(nested)) {
+        for (const candidate of nested) {
+          if (typeof candidate === 'string') {
+            const normalized = normalizeTag(candidate)
+            if (normalized) acc.add(normalized)
+          }
+        }
+      }
+    }
+    collectCwdsFromValue(nested, acc, seen)
+  }
+}
+
+function collectFromMeta(meta: SessionMetaParsed | undefined, acc: Set<string>) {
+  if (!meta) return
+  collectCwdsFromValue(meta as unknown as Record<string, unknown>, acc, new WeakSet())
+}
+
+function collectFromEvent(event: ResponseItemParsed, acc: Set<string>) {
+  collectCwdsFromValue(event as unknown as Record<string, unknown>, acc, new WeakSet())
+}
+
+export function extractCwdTagsFromText(text: string, maxTags = MAX_TAGS_DEFAULT): string[] {
+  const acc = new Set<string>()
+  if (!text) return []
+  const lines = text.split(/\r?\n/)
+  let metaProcessed = false
+
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+
+    if (!metaProcessed) {
+      metaProcessed = true
+      const metaResult = parseSessionMetaLine(line)
+      if (metaResult.success) {
+        collectFromMeta(metaResult.data, acc)
+        if (acc.size >= maxTags) break
+      }
+      continue
+    }
+
+    const eventResult = parseResponseItemLine(line)
+    if (!eventResult.success) continue
+    collectFromEvent(eventResult.data, acc)
+    if (acc.size >= maxTags) break
+  }
+
+  return Array.from(acc).slice(0, maxTags)
+}
+
+export async function fetchCwdTagsFromUrl(url: string, options?: { signal?: AbortSignal; maxTags?: number }): Promise<string[]> {
+  const res = await fetch(url, { signal: options?.signal })
+  if (!res.ok) {
+    throw new Error(`Failed to fetch session: ${res.status} ${res.statusText}`)
+  }
+  const text = await res.text()
+  const limit = options?.maxTags ?? MAX_TAGS_DEFAULT
+  return extractCwdTagsFromText(text, limit)
+}
+
+export function extractCwdTagsFromEvents(meta: SessionMetaParsed | undefined, events: readonly ResponseItemParsed[], maxTags = MAX_TAGS_DEFAULT): string[] {
+  const acc = new Set<string>()
+  collectFromMeta(meta, acc)
+  for (const event of events) {
+    collectFromEvent(event, acc)
+    if (acc.size >= maxTags) break
+  }
+  return Array.from(acc).slice(0, maxTags)
+}


### PR DESCRIPTION
## Summary
- fetch session files on demand to derive cwd tags and display them alongside each entry in the loader
- add utilities for extracting cwd tags from JSONL sessions and cover them with unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb2dc5d5488328be8a5e599e83c4fe