### PR TITLE
Add muted badge variant and refresh badge styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -710,8 +710,8 @@ function AppInner() {
         {scanStats && (
           <div className="mt-2 text-xs">
             <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="secondary">Scanned {scanStats.scanned}</Badge>
-              <Badge variant="secondary">Ignored {scanStats.ignored}</Badge>
+              <Badge variant="muted">Scanned {scanStats.scanned}</Badge>
+              <Badge variant="muted">Ignored {scanStats.ignored}</Badge>
               {scanStats.aborted && <span className="text-amber-600">Scan stopped early</span>}
             </div>
             {scanStats.topIgnored.length > 0 && (

--- a/src/components/ApplyPatchView.tsx
+++ b/src/components/ApplyPatchView.tsx
@@ -37,10 +37,10 @@ export default function ApplyPatchView({ item, pairedResultMeta }: ApplyPatchVie
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
-        <Badge variant="secondary">apply_patch</Badge>
+        <Badge variant="muted">apply_patch</Badge>
         {typeof item.durationMs === 'number' && <span className="text-gray-400">{item.durationMs} ms</span>}
         {status && (
-          <Badge variant={status.exitCode === 0 ? 'secondary' : 'destructive'}>
+          <Badge variant={status.exitCode === 0 ? 'muted' : 'destructive'}>
             {status.exitCode === 0 ? 'success' : `exit ${status.exitCode}`} {status.duration != null && `• ${status.duration}s`}
           </Badge>
         )}

--- a/src/components/ChatPair.tsx
+++ b/src/components/ChatPair.tsx
@@ -21,7 +21,7 @@ export default function ChatPair({ user, assistant }: ChatPairProps) {
     <div data-testid="chat-pair" className="grid grid-cols-2 gap-4">
       <div className="justify-self-start space-y-1">
         <div className="text-xs text-gray-500 flex items-center gap-2">
-          <Badge variant="secondary">user</Badge>
+          <Badge variant="muted">user</Badge>
         </div>
         <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2">
           {renderContent(user.content)}
@@ -30,7 +30,7 @@ export default function ChatPair({ user, assistant }: ChatPairProps) {
       {assistant && (
         <div className="justify-self-end space-y-1">
           <div className="text-xs text-gray-500 flex items-center gap-2 justify-end">
-            <Badge variant="secondary">assistant</Badge>
+            <Badge variant="muted">assistant</Badge>
           </div>
           <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2 text-right">
             {renderContent(assistant.content)}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -49,7 +49,7 @@ function MessageEventView({ item, highlight }: { item: Extract<ResponseItem, { t
   return (
     <div className="space-y-2">
       <div className="text-xs text-gray-500 flex flex-wrap gap-2 items-center">
-        <Badge variant="secondary">{item.role}</Badge>
+        <Badge variant="muted">{item.role}</Badge>
         {item.model && <span className="text-gray-400">{item.model}</span>}
       </div>
       <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 rounded p-2 max-h-64 overflow-auto">
@@ -69,7 +69,7 @@ function LocalShellCallView({ item, highlight }: { item: Extract<ResponseItem, {
         <code className="bg-gray-100 px-1.5 py-0.5 rounded"><Highlight text={item.command} query={highlight} /></code>
         {item.cwd && <span className="text-gray-400">cwd: {item.cwd}</span>}
         {typeof item.exitCode === 'number' && (
-          <Badge variant={item.exitCode === 0 ? 'secondary' : 'destructive'}>
+          <Badge variant={item.exitCode === 0 ? 'muted' : 'destructive'}>
             exit {item.exitCode}
           </Badge>
         )}
@@ -94,7 +94,7 @@ function LocalShellCallView({ item, highlight }: { item: Extract<ResponseItem, {
 
       {patchOps.length > 0 && (
         <div className="space-y-2">
-          <Badge variant="secondary">apply_patch</Badge>
+          <Badge variant="muted">apply_patch</Badge>
           {patchOps.map((op, i) => {
             const sides = parseUnifiedDiffToSides(op.unifiedDiff)
             return (
@@ -204,7 +204,7 @@ function FunctionCallView({ item }: { item: Extract<ResponseItem, { type: 'Funct
   return (
     <div className="space-y-2">
       <div className="text-xs text-gray-500 flex flex-wrap items-center gap-2">
-        <Badge variant="secondary">{item.name}</Badge>
+        <Badge variant="muted">{item.name}</Badge>
         {typeof item.durationMs === 'number' && <span className="text-gray-400">{item.durationMs} ms</span>}
       </div>
       {item.args !== undefined && (
@@ -229,7 +229,7 @@ function WebSearchCallView({ item }: { item: Extract<ResponseItem, { type: 'WebS
       <div className="text-xs text-gray-500 flex flex-wrap items-center gap-2">
         <span>query:</span>
         <code className="bg-gray-100 px-1.5 py-0.5 rounded">{item.query}</code>
-        {item.provider && <Badge variant="secondary">{item.provider}</Badge>}
+        {item.provider && <Badge variant="muted">{item.provider}</Badge>}
       </div>
       {item.results && item.results.length > 0 ? (
         <ul className="list-disc pl-5 space-y-1">
@@ -257,7 +257,7 @@ function CustomToolCallView({ item }: { item: Extract<ResponseItem, { type: 'Cus
   return (
     <div className="space-y-2">
       <div className="text-xs text-gray-500 flex flex-wrap items-center gap-2">
-        <Badge variant="secondary">{item.toolName}</Badge>
+        <Badge variant="muted">{item.toolName}</Badge>
       </div>
       {item.input !== undefined && (
         <div>
@@ -290,7 +290,7 @@ export default function EventCard({ item, index, bookmarkKey, onRevealFile, onOp
         <Badge>{(item as any).type ?? 'Event'}</Badge>
         {typeof index === 'number' && <div className="text-xs text-gray-500">#{index + 1}</div>}
         {at && <div className="text-xs text-gray-500">{formatAt(at)}</div>}
-        {has(key) && <Badge variant="secondary">Bookmarked</Badge>}
+        {has(key) && <Badge variant="muted">Bookmarked</Badge>}
         {containsApplyPatchAnywhere(item) && <Badge variant="outline" title="This event references apply_patch">✚ apply_patch</Badge>}
       </CardHeader>
       <CardContent>

--- a/src/components/MetadataPanel.tsx
+++ b/src/components/MetadataPanel.tsx
@@ -58,7 +58,7 @@ export default function MetadataPanel({ meta }: MetadataPanelProps) {
           {git.dirty !== undefined && (
             <Row
               label="Dirty"
-              value={<Badge variant={git.dirty ? 'destructive' : 'secondary'}>{String(git.dirty)}</Badge>}
+              value={<Badge variant={git.dirty ? 'destructive' : 'muted'}>{String(git.dirty)}</Badge>}
             />
           )}
         </div>

--- a/src/components/SessionsList.tsx
+++ b/src/components/SessionsList.tsx
@@ -361,7 +361,7 @@ function Row({
               tags?.map((tag) => (
                 <Badge
                   key={tag}
-                  variant="secondary"
+                  variant="muted"
                   title={tag}
                   className="max-w-[16rem] overflow-hidden text-ellipsis whitespace-nowrap"
                 >

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { cn } from '../../utils/cn'
 
-type Variant = 'default' | 'secondary' | 'destructive' | 'outline'
+type Variant = 'default' | 'secondary' | 'destructive' | 'outline' | 'muted'
 
 const base = 'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium'
 
@@ -10,6 +10,8 @@ const variants: Record<Variant, string> = {
   default: 'border-transparent bg-primary text-primary-foreground',
   // Neutral chip: subtle border only
   secondary: 'border-foreground/20 text-foreground',
+  // GitHub-style tint: soft background with matching border
+  muted: 'border-foreground/10 bg-foreground/5 text-foreground dark:border-foreground/20 dark:bg-foreground/15',
   destructive: 'border-transparent bg-red-600 text-white',
   outline: 'border-primary text-primary'
 }


### PR DESCRIPTION
## Summary
- add a GitHub-inspired muted badge variant with a subtle tint
- switch session tags and other neutral badges to the muted styling for consistency
- leave destructive/outline badges untouched while improving neutral status readability

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb388c8c408328be90a0a97468d648