### PR TITLE
Fix diff viewer baseline orientation

### DIFF
--- a/src/components/TwoFileDiffViewer.tsx
+++ b/src/components/TwoFileDiffViewer.tsx
@@ -348,6 +348,10 @@ export default function TwoFileDiffViewer({
     return `${sanitizeFilenameSegment(leftFile.name)}-vs-${sanitizeFilenameSegment(rightFile.name)}`
   }, [leftFile, rightFile])
 
+  const baselineSide = isBaselineLeft ? leftFile : rightFile
+  const comparisonSide = isBaselineLeft ? rightFile : leftFile
+  const diffPath = comparisonSide?.name ?? baselineSide?.name ?? 'diff'
+
   const handleFiles = React.useCallback(
     async (list: FileList | null, explicitTarget?: 'left' | 'right') => {
       if (!list || list.length === 0) {
@@ -663,9 +667,9 @@ export default function TwoFileDiffViewer({
                     <Panel defaultSize={68} minSize={35} className="h-full">
                       <div ref={diffPanelRef} className="flex h-full flex-col overflow-hidden">
                         <DiffView
-                          path={rightFile?.name || leftFile?.name || 'diff'}
-                          original={leftFile?.content ?? ''}
-                          modified={rightFile?.content ?? ''}
+                          path={diffPath}
+                          original={baselineSide?.content ?? ''}
+                          modified={comparisonSide?.content ?? ''}
                           height="100%"
                         />
                       </div>

--- a/src/components/__tests__/TwoFileDiffViewer.test.tsx
+++ b/src/components/__tests__/TwoFileDiffViewer.test.tsx
@@ -1,13 +1,14 @@
 /* @vitest-environment jsdom */
 import '@testing-library/jest-dom/vitest'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 import TwoFileDiff, { exportDiff } from '../TwoFileDiff'
 
 const downloadTextMock = vi.fn()
 const diff2HtmlMock = vi.fn(() => '<div class="d2h-wrapper"></div>')
+const diffViewMock = vi.fn((props: any) => React.createElement('div', { 'data-testid': 'mock-diff-view' }))
 
 vi.mock('../../utils/download', () => ({ downloadText: downloadTextMock }))
 
@@ -17,6 +18,11 @@ vi.mock('diff2html', () => ({
 
 vi.mock('@monaco-editor/react', () => ({
   DiffEditor: () => React.createElement('div', { 'data-testid': 'monaco-diff' }),
+}))
+
+vi.mock('../DiffView', () => ({
+  __esModule: true,
+  default: (props: any) => diffViewMock(props),
 }))
 
 vi.mock('react-resizable-panels', () => {
@@ -56,6 +62,11 @@ if (typeof window !== 'undefined') {
 beforeEach(() => {
   downloadTextMock.mockClear()
   diff2HtmlMock.mockClear()
+  diffViewMock.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
 })
 
 describe('TwoFileDiffViewer', () => {
@@ -133,6 +144,31 @@ describe('TwoFileDiffViewer', () => {
     const minimize = screen.getByRole('button', { name: /minimize diff viewer/i })
     fireEvent.click(minimize)
     expect(minimize).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('sends baseline content to DiffView when baseline is on the left', () => {
+    render(
+      React.createElement(TwoFileDiff, {
+        initialLeftFile: { name: 'left.txt', content: 'baseline content' },
+        initialRightFile: { name: 'right.txt', content: 'proposed content' },
+      })
+    )
+    const call = diffViewMock.mock.calls.at(-1)?.[0]
+    expect(call?.original).toBe('baseline content')
+    expect(call?.modified).toBe('proposed content')
+  })
+
+  it('sends baseline content to DiffView when baseline is on the right', () => {
+    render(
+      React.createElement(TwoFileDiff, {
+        initialLeftFile: { name: 'left.txt', content: 'baseline content' },
+        initialRightFile: { name: 'right.txt', content: 'proposed content' },
+        leftToRight: false,
+      })
+    )
+    const call = diffViewMock.mock.calls.at(-1)?.[0]
+    expect(call?.original).toBe('proposed content')
+    expect(call?.modified).toBe('baseline content')
   })
 
   it('exportDiff helper generates html diff', () => {


### PR DESCRIPTION
## Summary
- update the two-file diff viewer to send DiffView the correct baseline/comparison sides based on the current orientation
- add unit tests that verify DiffView receives the baseline content when it is on either side of the viewer

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdca47a6cc8328886ffa9e4425d19d