### PR TITLE
Auto-size two-file diff viewer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 2025-09-19 — Two-file diff viewer overhaul
 
 - Added the new `TwoFileDiffViewer` component with optional `leftLabel`,
-  `rightLabel`, `leftToRight`, `defaultExpanded`, and `defaultMinimized` props to
-  clarify ordering and initial window state.
+  `rightLabel`, `leftToRight`, and `defaultMinimized` props to clarify ordering
+  and initial window state.
 - Retained the legacy `TwoFileDiff` export as a thin wrapper for backwards
   compatibility while exposing the new `exportDiff` helper and type aliases.
 - Introduced accessible resizing via `react-resizable-panels`, including

--- a/docs/diff-viewer.md
+++ b/docs/diff-viewer.md
@@ -25,7 +25,9 @@ explicit file ordering, export tooling, and an accessible resizable layout.
 
 ## Window controls
 
-- **Expand** toggles a taller workspace (`54vh` → `70vh`).
+- The diff viewport auto-sizes to the taller editor content and grows as files
+  change. Extremely tall diffs clamp to ~85% of the viewport height and enable
+  outer scrolling.
 - **Minimize** collapses the body to the header so the viewer can be tucked
   away in crowded layouts. Restoring re-opens the last layout.
 
@@ -62,7 +64,7 @@ Run the Vite dev server (`npm run dev`) and open
 
 1. Default drop flow and notice
 2. Swapped orientation
-3. Expanded layout
+3. Auto-sized layout
 4. Resizable metadata panel
 5. Export presets
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1463,7 +1463,6 @@ function AppInner() {
               original={activeDiff.original}
               modified={activeDiff.modified}
               language={activeDiff.language}
-              height={"60vh"}
             />
           </CollapsibleCard>
         )

--- a/src/components/TwoFileDiffViewerDemo.tsx
+++ b/src/components/TwoFileDiffViewerDemo.tsx
@@ -117,13 +117,9 @@ export default function TwoFileDiffViewerDemo() {
           />
         </section>
         <section className="space-y-4">
-          <h2 className="text-xl font-semibold">3. Expanded workspace</h2>
-          <p className="text-sm text-slate-300">The viewer boots in expanded mode for long edits.</p>
-          <TwoFileDiffViewer
-            initialLeftFile={compactBaseline}
-            initialRightFile={compactProposed}
-            defaultExpanded
-          />
+          <h2 className="text-xl font-semibold">3. Auto-sized workspace</h2>
+          <p className="text-sm text-slate-300">The viewer grows to fit long edits without manual toggles.</p>
+          <TwoFileDiffViewer initialLeftFile={compactBaseline} initialRightFile={compactProposed} />
         </section>
         <section className="space-y-4">
           <h2 className="text-xl font-semibold">4. Minimized start</h2>
@@ -147,7 +143,6 @@ export default function TwoFileDiffViewerDemo() {
             initialRightFile={exportSampleNew}
             leftLabel="Main branch"
             rightLabel="Feature branch"
-            defaultExpanded
           />
         </section>
       </main>


### PR DESCRIPTION
## Summary
- teach DiffView to measure Monaco content height, clamp the viewport, and relayout on container size changes
- let the two-file viewer drive DiffView with the measured height, clamp to ~85% of the window, and remove the expand control
- update docs, demo, and tests to describe and verify the new auto-sizing behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdca47a6cc8328886ffa9e4425d19d